### PR TITLE
Update README because no longer a disassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/pret/pmd-red/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/pret/pmd-red/actions/workflows/build.yml)
 
-This is a disassembly of Pokémon Mystery Dungeon: Red Rescue Team.
+This is a decompilation of Pokémon Mystery Dungeon: Red Rescue Team.
 
 It builds the following rom:
 


### PR DESCRIPTION
This PR notes that the readme hasn't been updated since this decompilation was only a disassembly and corrects that in this commit.