### PR TITLE
Resolve incbin calculation errors in calcrom.pl

### DIFF
--- a/.github/calcrom/calcrom.pl
+++ b/.github/calcrom/calcrom.pl
@@ -69,7 +69,7 @@ my $partial_doc_cmd = "grep '_[0-38-9][0-9a-fA-F]\\{5,6\\}'";
 
 my $count_cmd = "wc -l";
 
-my $incbin_cmd = "find \"\$(dirname $elffname)\" \\( -name '*.s' -o -name '*.inc' \\) -exec cat {} ';' | grep -oE '^\\s*\\.incbin\\s*\"[^\"]+\"\s*,\\s*(0x)?[0-9a-fA-F]+\\s*,\\s*(0x)?[0-9a-fA-F]+' -";
+my $incbin_cmd = "find \"\$(dirname $elffname)\" \\( -name '*.s' -o -name '*.inc' \\) -exec cat {} ';' | grep -oE '^\\s*\\.incbin\\s*\"[^\"]+\"\s*,\\s*(0x)?[0-9a-fA-F]+\\s*,\\s*(0x)?[0-9a-fA-F]+' - | awk '{\$1=\$1;print}' | sort | uniq";
 
 # It sucks that we have to run this three times, but I can't figure out how to get
 # stdin working for subcommands in perl while still having a timeout. It's decently


### PR DESCRIPTION
This trims, sorts, and deduplicates the results of the incbin command; which resolves the overcounting that was previously displayed. I don't know why the command was finding duplicates; I only resolved the symptoms, not the cause.

Trimming (the awk command) is necessary; there are some lines that differ only in the number of spaces at the beginning of the line.

The runtime of calcrom did increase by about ~25%, so this may need an increase in the timeout if this takes substantially longer in the CI than on my computer.

I can be contacted at whengryphonsfly on Discord.

Old:
```
725060 total bytes of code
309176 bytes of code in src (42.6414%)
415884 bytes of code in asm (57.3586%)

224158 total symbols
8412 symbols documented (3.7527%)
300 symbols partially documented (0.1338%)
215446 symbols undocumented (96.1135%)

32059292 total bytes of data
62051 bytes of data in src (0.1936%)
31997241 bytes of data in data (99.8064%)

82851021 bytes of data in 525417 incbins (258.4306%)

real	0m15.133s
user	0m19.095s
sys	0m0.688s
```

New:
```
725060 total bytes of code
309176 bytes of code in src (42.6414%)
415884 bytes of code in asm (57.3586%)

224158 total symbols
8412 symbols documented (3.7527%)
300 symbols partially documented (0.1338%)
215446 symbols undocumented (96.1135%)

32059292 total bytes of data
62051 bytes of data in src (0.1936%)
31997241 bytes of data in data (99.8064%)

27617007 bytes of data in 175139 incbins (86.1435%)

real	0m19.436s
user	0m21.523s
sys	0m0.786s
```