### PR TITLE
[decomp] math: decompile operations for 24.8 fixed-point numbers

### DIFF
--- a/asm/code_806E8B0.s
+++ b/asm/code_806E8B0.s
@@ -186,7 +186,7 @@ _0806EC24:
 	lsls r1, r4, 2
 	adds r1, r2
 	ldr r1, [r1]
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r2, r0, 0
 	ldr r0, [sp, 0x80]
 	lsls r4, r0, 2
@@ -195,7 +195,7 @@ _0806EC24:
 	adds r0, r4
 	ldr r1, [r0]
 	adds r0, r2, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r2, r0, 0
 	str r5, [sp, 0x88]
 	cmp r2, 0
@@ -272,14 +272,14 @@ _0806ECCC:
 	lsls r1, r3, 2
 	adds r1, r2
 	ldr r1, [r1]
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r2, r0, 0
 	ldr r0, [sp, 0x7C]
 	adds r0, 0x34
 	adds r0, r4
 	ldr r1, [r0]
 	adds r0, r2, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	cmp r0, 0
 	bge _0806ED0E
 	adds r0, 0xFF

--- a/asm/code_8077274_1.s
+++ b/asm/code_8077274_1.s
@@ -316,7 +316,7 @@ _0807AD84:
 	bgt _0807AD96
 	ldr r0, [r4, 0x1C]
 	movs r1, 0xAA
-	bl sub_8009DA4
+	bl s24_8_mul
 	str r0, [r4, 0x1C]
 	cmp r0, 0xFF
 	bgt _0807AD7C

--- a/asm/file_system.s
+++ b/asm/file_system.s
@@ -5,179 +5,8 @@
 
 	.text
 
-	thumb_func_start sub_8009D8C
-sub_8009D8C:
-	push {lr}
-	cmp r0, r2
-	bcc _08009D9A
-	cmp r0, r2
-	bhi _08009D9E
-	cmp r1, r3
-	bcs _08009D9E
-_08009D9A:
-	movs r0, 0x1
-	b _08009DA0
-_08009D9E:
-	movs r0, 0
-_08009DA0:
-	pop {r1}
-	bx r1
-	thumb_func_end sub_8009D8C
-
-	thumb_func_start sub_8009DA4
-sub_8009DA4:
-	push {r4,r5,lr}
-	lsrs r2, r0, 31
-	adds r5, r2, 0
-	lsrs r3, r1, 31
-	adds r4, r3, 0
-	cmp r0, 0
-	beq _08009DB6
-	cmp r1, 0
-	bne _08009DBA
-_08009DB6:
-	movs r0, 0
-	b _08009DD0
-_08009DBA:
-	cmp r2, 0
-	beq _08009DC0
-	negs r0, r0
-_08009DC0:
-	cmp r3, 0
-	beq _08009DC6
-	negs r1, r1
-_08009DC6:
-	bl sub_8009E14
-	cmp r5, r4
-	beq _08009DD0
-	negs r0, r0
-_08009DD0:
-	pop {r4,r5}
-	pop {r1}
-	bx r1
-	thumb_func_end sub_8009DA4
-
-	thumb_func_start sub_8009DD8
-sub_8009DD8:
-	push {r4,r5,lr}
-	lsrs r2, r0, 31
-	adds r5, r2, 0
-	lsrs r3, r1, 31
-	adds r4, r3, 0
-	cmp r1, 0
-	bne _08009DF0
-	ldr r0, _08009DEC
-	b _08009E0E
-	.align 2, 0
-_08009DEC: .4byte 0x7fffffff
-_08009DF0:
-	cmp r0, 0
-	bne _08009DF8
-	movs r0, 0
-	b _08009E0E
-_08009DF8:
-	cmp r2, 0
-	beq _08009DFE
-	negs r0, r0
-_08009DFE:
-	cmp r3, 0
-	beq _08009E04
-	negs r1, r1
-_08009E04:
-	bl sub_8009EA0
-	cmp r5, r4
-	beq _08009E0E
-	negs r0, r0
-_08009E0E:
-	pop {r4,r5}
-	pop {r1}
-	bx r1
-	thumb_func_end sub_8009DD8
-
-	thumb_func_start sub_8009E14
-sub_8009E14:
-	push {r4-r7,lr}
-	mov r7, r9
-	mov r6, r8
-	push {r6,r7}
-	cmp r0, 0
-	beq _08009E24
-	cmp r1, 0
-	bne _08009E28
-_08009E24:
-	movs r0, 0
-	b _08009E94
-_08009E28:
-	movs r5, 0
-	adds r3, r0, 0
-	mov r12, r5
-	movs r6, 0
-	movs r4, 0
-	movs r0, 0x80
-	lsls r0, 24
-	mov r8, r0
-	movs r7, 0x3F
-	mov r9, r7
-_08009E3C:
-	adds r2, r4, 0
-	movs r0, 0x1
-	ands r0, r1
-	cmp r0, 0
-	beq _08009E50
-	adds r4, r3
-	adds r6, r5
-	cmp r2, r4
-	bls _08009E50
-	adds r6, 0x1
-_08009E50:
-	lsrs r1, 1
-	movs r2, 0x1
-	mov r0, r12
-	ands r0, r2
-	cmp r0, 0
-	beq _08009E60
-	mov r0, r8
-	orrs r1, r0
-_08009E60:
-	mov r7, r12
-	lsrs r7, 1
-	mov r12, r7
-	lsls r5, 1
-	adds r0, r3, 0
-	mov r7, r8
-	ands r0, r7
-	cmp r0, 0
-	beq _08009E74
-	orrs r5, r2
-_08009E74:
-	lsls r3, 1
-	movs r0, 0x1
-	negs r0, r0
-	add r9, r0
-	mov r7, r9
-	cmp r7, 0
-	bge _08009E3C
-	lsrs r1, r4, 7
-	ands r1, r2
-	lsrs r4, 8
-	lsls r0, r6, 24
-	orrs r4, r0
-	cmp r1, 0
-	beq _08009E92
-	adds r4, 0x1
-_08009E92:
-	adds r0, r4, 0
-_08009E94:
-	pop {r3,r4}
-	mov r8, r3
-	mov r9, r4
-	pop {r4-r7}
-	pop {r1}
-	bx r1
-	thumb_func_end sub_8009E14
-
-	thumb_func_start sub_8009EA0
-sub_8009EA0:
+	thumb_func_start u24_8_div
+u24_8_div:
 	push {r4-r7,lr}
 	mov r7, r10
 	mov r6, r9
@@ -246,7 +75,7 @@ _08009F10:
 	adds r1, r4, 0
 	movs r2, 0
 	mov r3, r10
-	bl sub_8009D8C
+	bl u32_pair_less_than
 	lsls r0, 24
 	cmp r0, 0
 	bne _08009F3A
@@ -287,7 +116,7 @@ _08009F58:
 	pop {r4-r7}
 	pop {r1}
 	bx r1
-	thumb_func_end sub_8009EA0
+	thumb_func_end u24_8_div
 
 	thumb_func_start sub_8009F68
 sub_8009F68:
@@ -310,12 +139,12 @@ _08009F7E:
 	beq _08009F90
 	adds r0, r7, 0
 	adds r1, r5, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r7, r0, 0
 _08009F90:
 	adds r0, r5, 0
 	adds r1, r5, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r5, r0, 0
 	asrs r4, 1
 	cmp r4, 0
@@ -326,7 +155,7 @@ _08009FA0:
 	movs r0, 0x80
 	lsls r0, 1
 	adds r1, r7, 0
-	bl sub_8009DD8
+	bl s24_8_div
 	b _08009FB2
 _08009FB0:
 	adds r0, r7, 0
@@ -361,25 +190,25 @@ _08009FD4:
 _08009FDA:
 	adds r0, r6, 0
 	adds r1, r5, 0
-	bl sub_8009DD8
+	bl s24_8_div
 	adds r4, r0, 0
 	adds r1, r4, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r4, r0, 0
 	movs r0, 0x80
 	lsls r0, 3
 	adds r1, r4, r0
 	adds r0, r4, 0
-	bl sub_8009DD8
+	bl s24_8_div
 	adds r4, r0, 0
 	adds r0, r5, 0
 	adds r1, r4, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	lsls r0, 1
 	adds r5, r0
 	adds r0, r6, 0
 	adds r1, r4, 0
-	bl sub_8009DA4
+	bl s24_8_mul
 	adds r6, r0, 0
 	subs r7, 0x1
 	cmp r7, 0
@@ -718,6 +547,7 @@ _0800A254:
 _0800A258: .4byte gFastUnknownFn1Lookup
 	thumb_func_end sub_800A0B0
 
+// invert signed lex pair
 	thumb_func_start sub_800A25C
 sub_800A25C:
 	push {lr}
@@ -738,6 +568,7 @@ _0800A276:
 	bx r0
 	thumb_func_end sub_800A25C
 
+// absolute value of signed lex pair
 	thumb_func_start sub_800A27C
 sub_800A27C:
 	push {lr}
@@ -842,7 +673,7 @@ _0800A314:
 	ldr r3, [r2, 0x4]
 	adds r0, r4, 0
 	adds r2, r5, 0
-	bl sub_8009D8C
+	bl u32_pair_less_than
 	lsls r0, 24
 	lsrs r0, 24
 	b _0800A346
@@ -857,7 +688,7 @@ _0800A32E:
 	ldr r3, [r2, 0x4]
 	adds r0, r4, 0
 	adds r2, r5, 0
-	bl sub_8009D8C
+	bl u32_pair_less_than
 	movs r1, 0
 	lsls r0, 24
 	cmp r0, 0
@@ -1287,7 +1118,7 @@ _0800A656:
 	adds r1, r4, 0
 	ldr r2, [sp, 0x4]
 	ldr r3, [sp, 0x8]
-	bl sub_8009D8C
+	bl u32_pair_less_than
 	lsls r0, 24
 	cmp r0, 0
 	bne _0800A680

--- a/src/math.c
+++ b/src/math.c
@@ -3,6 +3,7 @@
 
 extern u8 gFastMod3Lookup[];
 extern s16 gFastSinLookup[];
+extern u24_8 u24_8_div(u24_8 x, u24_8 y); // decomp in progress: https://decomp.me/scratch/pMyGD
 
 u32 fast_mod_3(s32 x) {
     if (x < 0x100) {
@@ -39,3 +40,121 @@ s32 cos_4096(s32 x) {
     return 0;
 }
 
+bool8 u32_pair_less_than(u32 x_hi, u32 x_lo, u32 y_hi, u32 y_lo) {
+    if ((u32)x_hi < (u32)y_hi) {
+        return TRUE;
+    } else if ((u32)x_hi > (u32)y_hi) {
+        return FALSE;
+    } else if (x_lo >= y_lo) {
+        return FALSE;
+    } else {
+        return TRUE;
+    }
+}
+
+s24_8 s24_8_mul(s24_8 x, s24_8 y) {
+    s24_8 ret;
+    bool8 sgn0 = x < 0;
+    bool8 sgn1 = y < 0;
+
+    if (x == 0) {
+        return 0;
+    }
+    if (y == 0) {
+        return 0;
+    }
+
+    if (sgn0) {
+        x = -x;
+    }
+    if (sgn1) {
+        y = -y;
+    }
+    ret = u24_8_mul(x, y);
+    if (sgn0 != sgn1) {
+        ret = -ret;
+    }
+    return ret;
+}
+
+s24_8 s24_8_div(s24_8 x, s24_8 y) { // signed division
+    s24_8 ret;
+    bool8 sgn0 = x < 0;
+    bool8 sgn1 = y < 0;
+
+    if (y == 0) {
+        return INT32_MAX;
+    }
+    if (x == 0) {
+        return 0;
+    }
+
+    if (sgn0) {
+        x = -x;
+    }
+    if (sgn1) {
+        y = -y;
+    }
+    ret = u24_8_div(x, y);
+    if (sgn0 != sgn1) {
+        ret = -ret;
+    }
+    return ret;
+}
+
+u24_8 u24_8_mul(u24_8 x, u24_8 y) {
+    // We need 64 bits for intermediate steps of the multiplication.
+    u32 x_h, x_l;
+    u32 y_h, y_l;
+    u32 out_h, out_l;
+
+    s32 i;
+    u32 high_bit_mask;
+    u32 round_up;
+
+    if (x == 0 || y == 0) {
+        return 0;
+    }
+
+    x_h = 0;
+    x_l = x;
+    y_h = 0;
+    y_l = y;
+    out_h = 0;
+    out_l = 0;
+    high_bit_mask = 0x80 << 0x18; // high bit of u32
+
+    for (i = 0; i < 64; ++i) {
+        u32 prev_out_l = out_l;
+        u32 y_bit = 1;
+        y_bit &= y_l;
+        if (y_bit) {
+            out_l += x_l;
+            out_h += x_h;
+            if (prev_out_l > out_l) {
+                ++out_h;
+            }
+        }
+
+        y_l >>= 1;
+        if (y_h & 1) {
+            y_l |= high_bit_mask;
+        }
+        y_h >>= 1;
+
+        x_h <<= 1;
+        if (x_l & high_bit_mask) {
+            x_h |= 1;
+        }
+        do {x_l <<= 1;} while(0); // wtf moment
+    }
+
+    round_up = (out_l >> 0x7) & 1;
+    out_l = (out_l >> 0x8) | (out_h << 0x18);
+
+    if (round_up) {
+        ++out_l;
+    }
+
+    return out_l;
+}

--- a/src/math.h
+++ b/src/math.h
@@ -1,6 +1,22 @@
 #ifndef GUARD_MATH_H
 #define GUARD_MATH_H
 
+#include "global.h"
+
+/**
+ * This type represents a signed 24.8 fixed-point number, where the 24 most
+ * significant bits are the integer part and the 8 least significant bits are
+ * the fractional part.
+ */
+typedef s32 s24_8;
+
+/**
+ * This type represents an unsigned 24.8 fixed-point number, where the 24 most
+ * significant bits are the integer part and the 8 least significant bits are
+ * the fractional part.
+ */
+typedef u32 u24_8;
+
 /**
  * This function computes a value modulo 3, using a lookup table for values less
  * than 0x100.
@@ -8,32 +24,79 @@
  * @warning This function performs an invalid memory access if x < 0.
  * Hopefully it's never actually used.
  *
- * @param s32 x     The value to get modulo 3. Must be non-negative.
+ * @param[in] x     The value to get modulo 3. Must be non-negative.
  *
- * @return u32      The value of x modulo 3.
+ * @return          The value of x modulo 3.
  */
 u32 fast_mod_3(s32 x);
 
 /**
- * This function computes the sine of the absolute value of x using a lookup
- * table. The period of the function is 4096, and the range is [-256, 256].
+ * This function computes the sine of the absolute value of `x` using a lookup
+ * table. The period of the function is `4096`, and the range is `[-256, 256]`.
  *
- * @param s32 x     The value to get the sine of.
+ * @param[in] x     The value to get the sine of.
  *
- * @return s32      `floor(256 * sin(pi * abs(x) / 2048))`
+ * @return          `floor(256 * sin(pi * abs(x) / 2048))` as a signed 32-bit integer.
  */
 s32 sin_abs_4096(s32 x);
 
 /**
- * This function computes the cosine of the absolute value of x using a lookup
- * table. The period of the function is 4096, and the range is [-256, 256].
+ * This function computes the cosine of of `x` using a lookup table. The period of
+ * the function is `4096`, and the range is `[-256, 256]`.
  *
  * @note Mathematically, `cos(abs(t)) = cos(t)`, unlike the case in `sin_abs_4096()` above.
  *
- * @param s32 x     The value to get the cosine of.
+ * @param[in] x     The value to get the cosine of.
  *
- * @return s32      `floor(256 * cos(pi * x / 2048))`
+ * @return          `floor(256 * cos(pi * x / 2048))` as a signed 32-bit integer.
  */
 s32 cos_4096(s32 x);
+
+/**
+ * This function lexicographically compares two pairs of u32s.
+ *
+ * @note The call signature of this might change if it makes sense to pack the
+ *       inputs into a struct representing, say, a 64-bit unsigned integer. Doing
+ *       so does affect the generated assembly; the current approach is the simplest
+ *       match.
+ *
+ * @param[in] x_hi  The high 32 bits of the first pair.
+ * @param[in] x_lo  The low 32 bits of the first pair.
+ * @param[in] y_hi  The high 32 bits of the second pair.
+ * @param[in] y_lo  The low 32 bits of the second pair.
+ *
+ * @return          `TRUE` if `x < y`, `FALSE` otherwise.
+ */
+bool8 u32_pair_less_than(u32 x_hi, u32 x_lo, u32 y_hi, u32 y_lo);
+
+/**
+ * This function multiplies two signed 24.8 fixed-point numbers.
+ *
+ * @param[in] x   The first factor.
+ * @param[in] y   The second factor.
+ *
+ * @return          The product `x*y` as a signed 24.8 fixed-point number.
+ */
+s24_8 s24_8_mul(s24_8 x, s24_8 y);
+
+/**
+ * This function divides two signed 24.8 fixed-point numbers.
+ *
+ * @param[in] x   The dividend.
+ * @param[in] y   The divisor.
+ *
+ * @returns       The quotient `x/y` as a signed 24.8 fixed-point number.
+ */
+s32 s24_8_div(s32 r0, s32 r1);
+
+/**
+ * This function multiplies two unsigned 24.8 fixed-point numbers.
+ *
+ * @param[in] x   The first factor.
+ * @param[in] y   The second factor.
+ *
+ * @return        The product `x*y` as an unsigned 24.8 fixed-point number.
+ */
+u24_8 u24_8_mul(u24_8 x, u24_8 y);
 
 #endif // GUARD_MATH_H

--- a/src/status.c
+++ b/src/status.c
@@ -15,6 +15,7 @@
 #include "code_8077274_1.h"
 #include "dungeon_movement.h"
 #include "structs/map.h"
+#include "math.h"
 
 extern u8 gAvailablePokemonNames[];
 extern u8 gUnknown_202DE58[];
@@ -158,7 +159,6 @@ extern bool8 sub_8071728(Entity * param_1, Entity * param_2, u8 param_3);
 extern void sub_8041FB4(Entity *r0, u32 r1);
 extern void sub_8041FD8(Entity *r0, u32 r1);
 extern void sub_80522F4(Entity *r1, Entity *r2, u8 *);
-extern s32 sub_8009DA4(s32, s32);
 extern void sub_804201C(Entity *r0, u32 r1);
 extern void sub_8041FFC(Entity *r0, u32 r1);
 extern void SetMessageArgument(char[], Entity*, u32);
@@ -216,7 +216,7 @@ void ChangeAttackMultiplierTarget(Entity *pokemon, Entity *target, u32 statStage
 {
   EntityInfo *entityInfo;
   s32 oldMulti;
-  
+
   if (!EntityExists(target)) {
     return;
   }
@@ -230,7 +230,7 @@ void ChangeAttackMultiplierTarget(Entity *pokemon, Entity *target, u32 statStage
   if ((param_4 < 0x100) && sub_8071728(pokemon,target,displayMessage)) {
     return;
   }
-  
+
   if ((HasHeldItem(target,ITEM_TWIST_BAND)) && (param_4 < 0x100)) {
     SetMessageArgument(gAvailablePokemonNames,target,0);
     sub_80522F4(pokemon,target,*gUnknown_80FD550);
@@ -256,7 +256,7 @@ void ChangeAttackMultiplierTarget(Entity *pokemon, Entity *target, u32 statStage
     sub_8041FB4(target,statStage);
   }
 
-  entityInfo->offensiveMultipliers[statStage] = sub_8009DA4(entityInfo->offensiveMultipliers[statStage],param_4);
+  entityInfo->offensiveMultipliers[statStage] = s24_8_mul(entityInfo->offensiveMultipliers[statStage],param_4);
 
   if (entityInfo->offensiveMultipliers[statStage] < 2) {
     entityInfo->offensiveMultipliers[statStage] = 2;
@@ -281,7 +281,7 @@ void ChangeDefenseMultiplierTarget(Entity *pokemon, Entity *target, u32 statStag
 {
   EntityInfo *entityInfo;
   s32 oldMulti;
-  
+
   if (!EntityExists(target)) {
     return;
   }
@@ -307,7 +307,7 @@ void ChangeDefenseMultiplierTarget(Entity *pokemon, Entity *target, u32 statStag
     sub_8041FFC(target,statStage);
   }
 
-  entityInfo->defensiveMultipliers[statStage] = sub_8009DA4(entityInfo->defensiveMultipliers[statStage],param_4);
+  entityInfo->defensiveMultipliers[statStage] = s24_8_mul(entityInfo->defensiveMultipliers[statStage],param_4);
 
   if (entityInfo->defensiveMultipliers[statStage] < 2) {
     entityInfo->defensiveMultipliers[statStage] = 2;
@@ -392,7 +392,7 @@ void LowerAccuracyStageTarget(Entity * pokemon, Entity * target, s32 statStage, 
 void CringeStatusTarget(Entity * pokemon,Entity * target, bool8 displayMessage)
 {
   EntityInfo *entityInfo;
-  
+
   if (EntityExists(target)) {
     if (!HasSafeguardStatus(pokemon, target, displayMessage)) {
       if (HasAbility(target, ABILITY_INNER_FOCUS)){
@@ -428,7 +428,7 @@ void ParalyzeStatusTarget(Entity * pokemon, Entity * target, bool8 displayMessag
   int index;
   bool8 bVar6;
   bool8 bVar7;
-  
+
   if ((EntityExists(target)) && (!HasSafeguardStatus(pokemon,target,displayMessage))) {
     if (HasAbility(target, ABILITY_LIMBER)) {
       SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -484,7 +484,7 @@ void RaiseMovementSpeedTarget(Entity * pokemon, Entity * target, s32 turns, bool
   s32 index;
   s32 movSpeed_1;
   EntityInfo *entityInfo;
-  
+
   if (!EntityExists(target)) {
     return;
   }
@@ -506,7 +506,7 @@ void RaiseMovementSpeedTarget(Entity * pokemon, Entity * target, s32 turns, bool
             entityInfo->speedUpCounters[index]  = turns;
             break;
         }
-    } 
+    }
     movSpeed_1 = CalcSpeedStage(target);
     if (movSpeed == movSpeed_1) {
         sub_80522F4(pokemon,target,*gUnknown_80FC298);
@@ -529,7 +529,7 @@ void LowerMovementSpeedTarget(Entity * pokemon, Entity * target, s32 levels, boo
   s32 index;
   s32 movSpeed_1;
   EntityInfo *entityInfo;
-  
+
   if (!EntityExists(target)) {
     return;
   }
@@ -571,7 +571,7 @@ void LowerMovementSpeedTarget(Entity * pokemon, Entity * target, s32 levels, boo
 void ConfuseStatusTarget(Entity * pokemon, Entity * target, bool8 displayMessage)
 {
   EntityInfo *entityInfo;
-  
+
   if (!EntityExists(target)) {
     return;
   }
@@ -611,7 +611,7 @@ void ConfuseStatusTarget(Entity * pokemon, Entity * target, bool8 displayMessage
 void CowerStatusTarget(Entity * pokemon, Entity * target, bool8 displayMessage)
 {
   EntityInfo *entityInfo;
-  
+
   if ((EntityExists(target)) && (!HasSafeguardStatus(pokemon,target,displayMessage))) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -676,7 +676,7 @@ void HealTargetHP(Entity *pokemon, Entity *target, s32 param_3, s32 param_4, boo
         if (displayMessage_u8)
             sub_80522F4(pokemon,target,*gUnknown_80FB204); // $m0's HP remained unchanged
     }
-    else if ((param_4 == 0) && (HP == 0)) 
+    else if ((param_4 == 0) && (HP == 0))
     {
         if (displayMessage_u8)
             sub_80522F4(pokemon,target,*gUnknown_80FB21C); // $m0 has full HP
@@ -858,7 +858,7 @@ void DestinyBondStatusTarget(Entity * pokemon, Entity * target)
   s32 index;
   u8 *linkedStatus;
   s32 zero;
-  
+
   if (((EntityExists(target)) && (GetEntityType(pokemon) == ENTITY_MONSTER)) &&
      (GetEntityType(target) == ENTITY_MONSTER)) {
         entityInfo = pokemon->info;
@@ -896,7 +896,7 @@ void DestinyBondStatusTarget(Entity * pokemon, Entity * target)
 void SureShotStatusTarget(Entity *pokemon, Entity * target, s32 turns)
 {
   EntityInfo *entityInfo;
-  
+
   if (EntityExists(target)) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -916,7 +916,7 @@ void SureShotStatusTarget(Entity *pokemon, Entity * target, s32 turns)
 void WhifferStatusTarget(Entity *pokemon, Entity * target, s32 turns)
 {
   EntityInfo *entityInfo;
-  
+
   if (EntityExists(target) && !HasSafeguardStatus(pokemon, target, TRUE)) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -936,7 +936,7 @@ void WhifferStatusTarget(Entity *pokemon, Entity * target, s32 turns)
 void FixedDamageStatusTarget(Entity *pokemon, Entity * target)
 {
   EntityInfo *entityInfo;
-  
+
   if (EntityExists(target)) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -956,7 +956,7 @@ void FixedDamageStatusTarget(Entity *pokemon, Entity * target)
 void FocusEnergyStatusTarget(Entity *pokemon, Entity * target)
 {
   EntityInfo *entityInfo;
-  
+
   if (EntityExists(target)) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -981,7 +981,7 @@ void sub_80783C4(Entity * pokemon, Entity * target, u8 param_3)
   Entity * entity2;
   ActionContainer action;
   s32 index;
-  
+
   if ((EntityExists(target)) && (!HasSafeguardStatus(pokemon, target, TRUE))) {
     targetEntityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -1038,7 +1038,7 @@ void CurseStatusTarget(Entity *pokemon, Entity * target)
   s32 HP;
   EntityInfo * pokemonEntityData;
   EntityInfo * targetEntityInfo;
-  
+
 
   if ((EntityExists(pokemon) ) && (EntityExists(target))) {
     pokemonEntityData = pokemon->info;
@@ -1078,7 +1078,7 @@ void SnatchStatusTarget(Entity * pokemon, Entity * target)
   s32 index;
   EntityInfo * targetEntityInfo;
   EntityInfo * targetEntityInfo2;
-  
+
   if (EntityExists(target)) {
     SendWaitingEndMessage(pokemon,target,STATUS_SNATCH);
 
@@ -1110,7 +1110,7 @@ void SnatchStatusTarget(Entity * pokemon, Entity * target)
 void TauntStatusTarget(Entity * pokemon, Entity * target)
 {
   EntityInfo *entityInfo;
-  
+
   if ((EntityExists(target)) && (!HasSafeguardStatus(pokemon,target,TRUE))) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -1130,7 +1130,7 @@ void TauntStatusTarget(Entity * pokemon, Entity * target)
 void HandleStockpile(Entity * pokemon, Entity * target)
 {
   EntityInfo *entityInfo;
-  
+
   if ((EntityExists(target))) {
     entityInfo = target->info;
     SetMessageArgument(gAvailablePokemonNames,target,0);
@@ -1152,7 +1152,7 @@ void InvisibleStatusTarget(Entity * pokemon, Entity * target)
 {
   EntityInfo * targetEntityInfo;
   EntityInfo * targetEntityInfo_1;
-  
+
   if (EntityExists(target)) {
     targetEntityInfo = target->info;
     targetEntityInfo_1 = targetEntityInfo;
@@ -1176,7 +1176,7 @@ void InvisibleStatusTarget(Entity * pokemon, Entity * target)
 void PerishSongTarget(Entity * pokemon, Entity * target)
 {
   EntityInfo * entityInfo;
-  
+
   if (EntityExists(target) && !HasSafeguardStatus(pokemon, target, TRUE)) {
     nullsub_82(target);
     entityInfo = target->info;
@@ -1197,7 +1197,7 @@ void EncoreStatusTarget(Entity *pokemon,Entity *target)
   Move *movePtr;
   int index;
   EntityInfo *EntityInfo;
-  
+
   EntityInfo = target->info;
   if ((EntityExists(target)) && (!HasSafeguardStatus(pokemon,target,TRUE))) {
     for(index = 0; index < MAX_MON_MOVES; index++)


### PR DESCRIPTION
This PR decomps:
- `u32_pair_less_than` (used in `u24_8_div`)
- `s24_8_mul`
- `u24_8_mul`
- `s24_8_div`

I'm currently working on `u24_8_div`, but it's a little tricky.
