### PR TITLE
Use explict/direct names for MonsterCategory

### DIFF
--- a/data/monster/monster_data.json
+++ b/data/monster/monster_data.json
@@ -7239,7 +7239,7 @@
     },
     {
         "name": "MonsterNameMewtwo",
-        "category": "MonsterCategoryNewSpeciestwo",
+        "category": "MonsterCategoryGenetic",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,

--- a/data/monster/monster_data.json
+++ b/data/monster/monster_data.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "MonsterNameNone",
-        "category": "MonsterCategoryNone",
+        "category": "MonsterCategoryEruption",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -44,7 +44,7 @@
     },
     {
         "name": "MonsterNameBulbasaur",
-        "category": "MonsterCategoryBulbasaur",
+        "category": "MonsterCategorySeed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -89,7 +89,7 @@
     },
     {
         "name": "MonsterNameIvysaur",
-        "category": "MonsterCategoryBulbasaur",
+        "category": "MonsterCategorySeed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -140,7 +140,7 @@
     },
     {
         "name": "MonsterNameVenusaur",
-        "category": "MonsterCategoryBulbasaur",
+        "category": "MonsterCategorySeed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -191,7 +191,7 @@
     },
     {
         "name": "MonsterNameCharmander",
-        "category": "MonsterCategoryCharmander",
+        "category": "MonsterCategoryLizard",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -236,7 +236,7 @@
     },
     {
         "name": "MonsterNameCharmeleon",
-        "category": "MonsterCategoryCharmeleon",
+        "category": "MonsterCategoryFlame",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -287,7 +287,7 @@
     },
     {
         "name": "MonsterNameCharizard",
-        "category": "MonsterCategoryCharmeleon",
+        "category": "MonsterCategoryFlame",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -340,7 +340,7 @@
     },
     {
         "name": "MonsterNameSquirtle",
-        "category": "MonsterCategorySquirtle",
+        "category": "MonsterCategoryTinyTurtle",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -385,7 +385,7 @@
     },
     {
         "name": "MonsterNameWartortle",
-        "category": "MonsterCategoryWartortle",
+        "category": "MonsterCategoryTurtle",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -436,7 +436,7 @@
     },
     {
         "name": "MonsterNameBlastoise",
-        "category": "MonsterCategoryBlastoise",
+        "category": "MonsterCategoryShellfish",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -488,7 +488,7 @@
     },
     {
         "name": "MonsterNameCaterpie",
-        "category": "MonsterCategoryCaterpie",
+        "category": "MonsterCategoryWorm",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -532,7 +532,7 @@
     },
     {
         "name": "MonsterNameMetapod",
-        "category": "MonsterCategoryMetapod",
+        "category": "MonsterCategoryCocoon",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -583,7 +583,7 @@
     },
     {
         "name": "MonsterNameButterfree",
-        "category": "MonsterCategoryButterfree",
+        "category": "MonsterCategoryButterfly",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -636,7 +636,7 @@
     },
     {
         "name": "MonsterNameWeedle",
-        "category": "MonsterCategoryWeedle",
+        "category": "MonsterCategoryHairyBug",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -680,7 +680,7 @@
     },
     {
         "name": "MonsterNameKakuna",
-        "category": "MonsterCategoryMetapod",
+        "category": "MonsterCategoryCocoon",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -731,7 +731,7 @@
     },
     {
         "name": "MonsterNameBeedrill",
-        "category": "MonsterCategoryBeedrill",
+        "category": "MonsterCategoryPoisonBee",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -783,7 +783,7 @@
     },
     {
         "name": "MonsterNamePidgey",
-        "category": "MonsterCategoryPidgey",
+        "category": "MonsterCategoryTinyBird",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -827,7 +827,7 @@
     },
     {
         "name": "MonsterNamePidgeotto",
-        "category": "MonsterCategoryPidgeotto",
+        "category": "MonsterCategoryBird",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -878,7 +878,7 @@
     },
     {
         "name": "MonsterNamePidgeot",
-        "category": "MonsterCategoryPidgeotto",
+        "category": "MonsterCategoryBird",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -929,7 +929,7 @@
     },
     {
         "name": "MonsterNameRattata",
-        "category": "MonsterCategoryRattata",
+        "category": "MonsterCategoryMouse",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -973,7 +973,7 @@
     },
     {
         "name": "MonsterNameRaticate",
-        "category": "MonsterCategoryRattata",
+        "category": "MonsterCategoryMouse",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1024,7 +1024,7 @@
     },
     {
         "name": "MonsterNameSpearow",
-        "category": "MonsterCategoryPidgey",
+        "category": "MonsterCategoryTinyBird",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1068,7 +1068,7 @@
     },
     {
         "name": "MonsterNameFearow",
-        "category": "MonsterCategoryFearow",
+        "category": "MonsterCategoryBeak",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1119,7 +1119,7 @@
     },
     {
         "name": "MonsterNameEkans",
-        "category": "MonsterCategoryEkans",
+        "category": "MonsterCategorySnake",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1164,7 +1164,7 @@
     },
     {
         "name": "MonsterNameArbok",
-        "category": "MonsterCategoryArbok",
+        "category": "MonsterCategoryCobra",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1215,7 +1215,7 @@
     },
     {
         "name": "MonsterNamePikachu",
-        "category": "MonsterCategoryRattata",
+        "category": "MonsterCategoryMouse",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1266,7 +1266,7 @@
     },
     {
         "name": "MonsterNameRaichu",
-        "category": "MonsterCategoryRattata",
+        "category": "MonsterCategoryMouse",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1316,7 +1316,7 @@
     },
     {
         "name": "MonsterNameSandshrew",
-        "category": "MonsterCategoryRattata",
+        "category": "MonsterCategoryMouse",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1359,7 +1359,7 @@
     },
     {
         "name": "MonsterNameSandslash",
-        "category": "MonsterCategoryRattata",
+        "category": "MonsterCategoryMouse",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1409,7 +1409,7 @@
     },
     {
         "name": "MonsterNameNidoran_F",
-        "category": "MonsterCategoryNidoran_F",
+        "category": "MonsterCategoryPoisonPin",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1452,7 +1452,7 @@
     },
     {
         "name": "MonsterNameNidorina",
-        "category": "MonsterCategoryNidoran_F",
+        "category": "MonsterCategoryPoisonPin",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1502,7 +1502,7 @@
     },
     {
         "name": "MonsterNameNidoqueen",
-        "category": "MonsterCategoryNidoqueen",
+        "category": "MonsterCategoryDrill",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1553,7 +1553,7 @@
     },
     {
         "name": "MonsterNameNidoran_M",
-        "category": "MonsterCategoryNidoran_F",
+        "category": "MonsterCategoryPoisonPin",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1596,7 +1596,7 @@
     },
     {
         "name": "MonsterNameNidorino",
-        "category": "MonsterCategoryNidoran_F",
+        "category": "MonsterCategoryPoisonPin",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1646,7 +1646,7 @@
     },
     {
         "name": "MonsterNameNidoking",
-        "category": "MonsterCategoryNidoqueen",
+        "category": "MonsterCategoryDrill",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1697,7 +1697,7 @@
     },
     {
         "name": "MonsterNameClefairy",
-        "category": "MonsterCategoryClefairy",
+        "category": "MonsterCategoryFairy",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1747,7 +1747,7 @@
     },
     {
         "name": "MonsterNameClefable",
-        "category": "MonsterCategoryClefairy",
+        "category": "MonsterCategoryFairy",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1797,7 +1797,7 @@
     },
     {
         "name": "MonsterNameVulpix",
-        "category": "MonsterCategoryVulpix",
+        "category": "MonsterCategoryFox",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1841,7 +1841,7 @@
     },
     {
         "name": "MonsterNameNinetales",
-        "category": "MonsterCategoryVulpix",
+        "category": "MonsterCategoryFox",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1893,7 +1893,7 @@
     },
     {
         "name": "MonsterNameJigglypuff",
-        "category": "MonsterCategoryJigglypuff",
+        "category": "MonsterCategoryBalloon",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1943,7 +1943,7 @@
     },
     {
         "name": "MonsterNameWigglytuff",
-        "category": "MonsterCategoryJigglypuff",
+        "category": "MonsterCategoryBalloon",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -1994,7 +1994,7 @@
     },
     {
         "name": "MonsterNameZubat",
-        "category": "MonsterCategoryZubat",
+        "category": "MonsterCategoryBat",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2039,7 +2039,7 @@
     },
     {
         "name": "MonsterNameGolbat",
-        "category": "MonsterCategoryZubat",
+        "category": "MonsterCategoryBat",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2091,7 +2091,7 @@
     },
     {
         "name": "MonsterNameOddish",
-        "category": "MonsterCategoryOddish",
+        "category": "MonsterCategoryWeed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2135,7 +2135,7 @@
     },
     {
         "name": "MonsterNameGloom",
-        "category": "MonsterCategoryOddish",
+        "category": "MonsterCategoryWeed",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2186,7 +2186,7 @@
     },
     {
         "name": "MonsterNameVileplume",
-        "category": "MonsterCategoryVileplume",
+        "category": "MonsterCategoryFlower",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2237,7 +2237,7 @@
     },
     {
         "name": "MonsterNameParas",
-        "category": "MonsterCategoryParas",
+        "category": "MonsterCategoryMushroom",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2281,7 +2281,7 @@
     },
     {
         "name": "MonsterNameParasect",
-        "category": "MonsterCategoryParas",
+        "category": "MonsterCategoryMushroom",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2332,7 +2332,7 @@
     },
     {
         "name": "MonsterNameVenonat",
-        "category": "MonsterCategoryVenonat",
+        "category": "MonsterCategoryInsect",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2376,7 +2376,7 @@
     },
     {
         "name": "MonsterNameVenomoth",
-        "category": "MonsterCategoryVenomoth",
+        "category": "MonsterCategoryPoisonMoth",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2428,7 +2428,7 @@
     },
     {
         "name": "MonsterNameDiglett",
-        "category": "MonsterCategoryDiglett",
+        "category": "MonsterCategoryMole",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2473,7 +2473,7 @@
     },
     {
         "name": "MonsterNameDugtrio",
-        "category": "MonsterCategoryDiglett",
+        "category": "MonsterCategoryMole",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2525,7 +2525,7 @@
     },
     {
         "name": "MonsterNameMeowth",
-        "category": "MonsterCategoryMeowth",
+        "category": "MonsterCategoryScratchCat",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2569,7 +2569,7 @@
     },
     {
         "name": "MonsterNamePersian",
-        "category": "MonsterCategoryPersian",
+        "category": "MonsterCategoryClassyCat",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2620,7 +2620,7 @@
     },
     {
         "name": "MonsterNamePsyduck",
-        "category": "MonsterCategoryPsyduck",
+        "category": "MonsterCategoryDuck",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2666,7 +2666,7 @@
     },
     {
         "name": "MonsterNameGolduck",
-        "category": "MonsterCategoryPsyduck",
+        "category": "MonsterCategoryDuck",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2718,7 +2718,7 @@
     },
     {
         "name": "MonsterNameMankey",
-        "category": "MonsterCategoryMankey",
+        "category": "MonsterCategoryPigMonkey",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2762,7 +2762,7 @@
     },
     {
         "name": "MonsterNamePrimeape",
-        "category": "MonsterCategoryMankey",
+        "category": "MonsterCategoryPigMonkey",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2812,7 +2812,7 @@
     },
     {
         "name": "MonsterNameGrowlithe",
-        "category": "MonsterCategoryGrowlithe",
+        "category": "MonsterCategoryPuppy",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2857,7 +2857,7 @@
     },
     {
         "name": "MonsterNameArcanine",
-        "category": "MonsterCategoryArcanine",
+        "category": "MonsterCategoryLegendary",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2909,7 +2909,7 @@
     },
     {
         "name": "MonsterNamePoliwag",
-        "category": "MonsterCategoryPoliwag",
+        "category": "MonsterCategoryTadpole",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -2954,7 +2954,7 @@
     },
     {
         "name": "MonsterNamePoliwhirl",
-        "category": "MonsterCategoryPoliwag",
+        "category": "MonsterCategoryTadpole",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3006,7 +3006,7 @@
     },
     {
         "name": "MonsterNamePoliwrath",
-        "category": "MonsterCategoryPoliwag",
+        "category": "MonsterCategoryTadpole",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3059,7 +3059,7 @@
     },
     {
         "name": "MonsterNameAbra",
-        "category": "MonsterCategoryAbra",
+        "category": "MonsterCategoryPsi",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3104,7 +3104,7 @@
     },
     {
         "name": "MonsterNameKadabra",
-        "category": "MonsterCategoryAbra",
+        "category": "MonsterCategoryPsi",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3155,7 +3155,7 @@
     },
     {
         "name": "MonsterNameAlakazam",
-        "category": "MonsterCategoryAbra",
+        "category": "MonsterCategoryPsi",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3208,7 +3208,7 @@
     },
     {
         "name": "MonsterNameMachop",
-        "category": "MonsterCategoryMachop",
+        "category": "MonsterCategorySuperpower",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3252,7 +3252,7 @@
     },
     {
         "name": "MonsterNameMachoke",
-        "category": "MonsterCategoryMachop",
+        "category": "MonsterCategorySuperpower",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3302,7 +3302,7 @@
     },
     {
         "name": "MonsterNameMachamp",
-        "category": "MonsterCategoryMachop",
+        "category": "MonsterCategorySuperpower",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3353,7 +3353,7 @@
     },
     {
         "name": "MonsterNameBellsprout",
-        "category": "MonsterCategoryVileplume",
+        "category": "MonsterCategoryFlower",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3398,7 +3398,7 @@
     },
     {
         "name": "MonsterNameWeepinbell",
-        "category": "MonsterCategoryWeepinbell",
+        "category": "MonsterCategoryFlycatcher",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3449,7 +3449,7 @@
     },
     {
         "name": "MonsterNameVictreebel",
-        "category": "MonsterCategoryWeepinbell",
+        "category": "MonsterCategoryFlycatcher",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3500,7 +3500,7 @@
     },
     {
         "name": "MonsterNameTentacool",
-        "category": "MonsterCategoryTentacool",
+        "category": "MonsterCategoryJellyfish",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3546,7 +3546,7 @@
     },
     {
         "name": "MonsterNameTentacruel",
-        "category": "MonsterCategoryTentacool",
+        "category": "MonsterCategoryJellyfish",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3599,7 +3599,7 @@
     },
     {
         "name": "MonsterNameGeodude",
-        "category": "MonsterCategoryGeodude",
+        "category": "MonsterCategoryRock",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3644,7 +3644,7 @@
     },
     {
         "name": "MonsterNameGraveler",
-        "category": "MonsterCategoryGeodude",
+        "category": "MonsterCategoryRock",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3696,7 +3696,7 @@
     },
     {
         "name": "MonsterNameGolem",
-        "category": "MonsterCategoryGolem",
+        "category": "MonsterCategoryMegaton",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3750,7 +3750,7 @@
     },
     {
         "name": "MonsterNamePonyta",
-        "category": "MonsterCategoryPonyta",
+        "category": "MonsterCategoryFireHorse",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3795,7 +3795,7 @@
     },
     {
         "name": "MonsterNameRapidash",
-        "category": "MonsterCategoryPonyta",
+        "category": "MonsterCategoryFireHorse",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3847,7 +3847,7 @@
     },
     {
         "name": "MonsterNameSlowpoke",
-        "category": "MonsterCategorySlowpoke",
+        "category": "MonsterCategoryDopey",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3893,7 +3893,7 @@
     },
     {
         "name": "MonsterNameSlowbro",
-        "category": "MonsterCategorySlowbro",
+        "category": "MonsterCategoryHermitCrab",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3946,7 +3946,7 @@
     },
     {
         "name": "MonsterNameMagnemite",
-        "category": "MonsterCategoryMagnemite",
+        "category": "MonsterCategoryMagnet",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -3993,7 +3993,7 @@
     },
     {
         "name": "MonsterNameMagneton",
-        "category": "MonsterCategoryMagnemite",
+        "category": "MonsterCategoryMagnet",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4046,7 +4046,7 @@
     },
     {
         "name": "MonsterNameFarfetch",
-        "category": "MonsterCategoryFarfetch",
+        "category": "MonsterCategoryWildDuck",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4091,7 +4091,7 @@
     },
     {
         "name": "MonsterNameDoduo",
-        "category": "MonsterCategoryDoduo",
+        "category": "MonsterCategoryTwinBird",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4136,7 +4136,7 @@
     },
     {
         "name": "MonsterNameDodrio",
-        "category": "MonsterCategoryDodrio",
+        "category": "MonsterCategoryTripleBird",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4188,7 +4188,7 @@
     },
     {
         "name": "MonsterNameSeel",
-        "category": "MonsterCategorySeel",
+        "category": "MonsterCategorySeaLion",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4232,7 +4232,7 @@
     },
     {
         "name": "MonsterNameDewgong",
-        "category": "MonsterCategorySeel",
+        "category": "MonsterCategorySeaLion",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4284,7 +4284,7 @@
     },
     {
         "name": "MonsterNameGrimer",
-        "category": "MonsterCategoryGrimer",
+        "category": "MonsterCategorySludge",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4328,7 +4328,7 @@
     },
     {
         "name": "MonsterNameMuk",
-        "category": "MonsterCategoryGrimer",
+        "category": "MonsterCategorySludge",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4379,7 +4379,7 @@
     },
     {
         "name": "MonsterNameShellder",
-        "category": "MonsterCategoryShellder",
+        "category": "MonsterCategoryBivalve",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4423,7 +4423,7 @@
     },
     {
         "name": "MonsterNameCloyster",
-        "category": "MonsterCategoryShellder",
+        "category": "MonsterCategoryBivalve",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4475,7 +4475,7 @@
     },
     {
         "name": "MonsterNameGastly",
-        "category": "MonsterCategoryGastly",
+        "category": "MonsterCategoryGas",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4520,7 +4520,7 @@
     },
     {
         "name": "MonsterNameHaunter",
-        "category": "MonsterCategoryGastly",
+        "category": "MonsterCategoryGas",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4572,7 +4572,7 @@
     },
     {
         "name": "MonsterNameGengar",
-        "category": "MonsterCategoryGengar",
+        "category": "MonsterCategoryShadow",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4626,7 +4626,7 @@
     },
     {
         "name": "MonsterNameOnix",
-        "category": "MonsterCategoryOnix",
+        "category": "MonsterCategoryRockSnake",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -4671,7 +4671,7 @@
     },
     {
         "name": "MonsterNameDrowzee",
-        "category": "MonsterCategoryDrowzee",
+        "category": "MonsterCategoryHypnosis",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4714,7 +4714,7 @@
     },
     {
         "name": "MonsterNameHypno",
-        "category": "MonsterCategoryDrowzee",
+        "category": "MonsterCategoryHypnosis",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4764,7 +4764,7 @@
     },
     {
         "name": "MonsterNameKrabby",
-        "category": "MonsterCategoryKrabby",
+        "category": "MonsterCategoryRiverCrab",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4809,7 +4809,7 @@
     },
     {
         "name": "MonsterNameKingler",
-        "category": "MonsterCategoryKingler",
+        "category": "MonsterCategoryPincer",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4861,7 +4861,7 @@
     },
     {
         "name": "MonsterNameVoltorb",
-        "category": "MonsterCategoryVoltorb",
+        "category": "MonsterCategoryBall",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4905,7 +4905,7 @@
     },
     {
         "name": "MonsterNameElectrode",
-        "category": "MonsterCategoryVoltorb",
+        "category": "MonsterCategoryBall",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -4956,7 +4956,7 @@
     },
     {
         "name": "MonsterNameExeggcute",
-        "category": "MonsterCategoryExeggcute",
+        "category": "MonsterCategoryEgg",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5000,7 +5000,7 @@
     },
     {
         "name": "MonsterNameExeggutor",
-        "category": "MonsterCategoryExeggutor",
+        "category": "MonsterCategoryCoconut",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5051,7 +5051,7 @@
     },
     {
         "name": "MonsterNameCubone",
-        "category": "MonsterCategoryCubone",
+        "category": "MonsterCategoryLonely",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5096,7 +5096,7 @@
     },
     {
         "name": "MonsterNameMarowak",
-        "category": "MonsterCategoryMarowak",
+        "category": "MonsterCategoryBoneKeeper",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5147,7 +5147,7 @@
     },
     {
         "name": "MonsterNameHitmonlee",
-        "category": "MonsterCategoryHitmonlee",
+        "category": "MonsterCategoryKicking",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5198,7 +5198,7 @@
     },
     {
         "name": "MonsterNameHitmonchan",
-        "category": "MonsterCategoryHitmonchan",
+        "category": "MonsterCategoryPunching",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5249,7 +5249,7 @@
     },
     {
         "name": "MonsterNameLickitung",
-        "category": "MonsterCategoryLickitung",
+        "category": "MonsterCategoryLicking",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5293,7 +5293,7 @@
     },
     {
         "name": "MonsterNameKoffing",
-        "category": "MonsterCategoryKoffing",
+        "category": "MonsterCategoryPoisonGas",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5337,7 +5337,7 @@
     },
     {
         "name": "MonsterNameWeezing",
-        "category": "MonsterCategoryKoffing",
+        "category": "MonsterCategoryPoisonGas",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5388,7 +5388,7 @@
     },
     {
         "name": "MonsterNameRhyhorn",
-        "category": "MonsterCategoryRhyhorn",
+        "category": "MonsterCategorySpikes",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5433,7 +5433,7 @@
     },
     {
         "name": "MonsterNameRhydon",
-        "category": "MonsterCategoryNidoqueen",
+        "category": "MonsterCategoryDrill",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5485,7 +5485,7 @@
     },
     {
         "name": "MonsterNameChansey",
-        "category": "MonsterCategoryExeggcute",
+        "category": "MonsterCategoryEgg",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5529,7 +5529,7 @@
     },
     {
         "name": "MonsterNameTangela",
-        "category": "MonsterCategoryTangela",
+        "category": "MonsterCategoryVine",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5572,7 +5572,7 @@
     },
     {
         "name": "MonsterNameKangaskhan",
-        "category": "MonsterCategoryKangaskhan",
+        "category": "MonsterCategoryParent",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5616,7 +5616,7 @@
     },
     {
         "name": "MonsterNameHorsea",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5660,7 +5660,7 @@
     },
     {
         "name": "MonsterNameSeadra",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5711,7 +5711,7 @@
     },
     {
         "name": "MonsterNameGoldeen",
-        "category": "MonsterCategoryGoldeen",
+        "category": "MonsterCategoryGoldfish",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5756,7 +5756,7 @@
     },
     {
         "name": "MonsterNameSeaking",
-        "category": "MonsterCategoryGoldeen",
+        "category": "MonsterCategoryGoldfish",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5808,7 +5808,7 @@
     },
     {
         "name": "MonsterNameStaryu",
-        "category": "MonsterCategoryStaryu",
+        "category": "MonsterCategoryStarShape",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5853,7 +5853,7 @@
     },
     {
         "name": "MonsterNameStarmie",
-        "category": "MonsterCategoryStarmie",
+        "category": "MonsterCategoryMysterious",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5906,7 +5906,7 @@
     },
     {
         "name": "MonsterNameMrMime",
-        "category": "MonsterCategoryMrMime",
+        "category": "MonsterCategoryBarrier",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5949,7 +5949,7 @@
     },
     {
         "name": "MonsterNameScyther",
-        "category": "MonsterCategoryScyther",
+        "category": "MonsterCategoryMantis",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -5993,7 +5993,7 @@
     },
     {
         "name": "MonsterNameJynx",
-        "category": "MonsterCategoryJynx",
+        "category": "MonsterCategoryHumanShape",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6044,7 +6044,7 @@
     },
     {
         "name": "MonsterNameElectabuzz",
-        "category": "MonsterCategoryElectabuzz",
+        "category": "MonsterCategoryElectric",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6094,7 +6094,7 @@
     },
     {
         "name": "MonsterNameMagmar",
-        "category": "MonsterCategoryMagmar",
+        "category": "MonsterCategorySpitfire",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6145,7 +6145,7 @@
     },
     {
         "name": "MonsterNamePinsir",
-        "category": "MonsterCategoryPinsir",
+        "category": "MonsterCategoryStagBeetle",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6188,7 +6188,7 @@
     },
     {
         "name": "MonsterNameTauros",
-        "category": "MonsterCategoryTauros",
+        "category": "MonsterCategoryWildBull",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6231,7 +6231,7 @@
     },
     {
         "name": "MonsterNameMagikarp",
-        "category": "MonsterCategoryMagikarp",
+        "category": "MonsterCategoryFish",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6275,7 +6275,7 @@
     },
     {
         "name": "MonsterNameGyarados",
-        "category": "MonsterCategoryGyarados",
+        "category": "MonsterCategoryAtrocious",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -6327,7 +6327,7 @@
     },
     {
         "name": "MonsterNameLapras",
-        "category": "MonsterCategoryLapras",
+        "category": "MonsterCategoryTransport",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -6373,7 +6373,7 @@
     },
     {
         "name": "MonsterNameDitto",
-        "category": "MonsterCategoryDitto",
+        "category": "MonsterCategoryTransform",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6416,7 +6416,7 @@
     },
     {
         "name": "MonsterNameEevee",
-        "category": "MonsterCategoryEevee",
+        "category": "MonsterCategoryEvolution",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6460,7 +6460,7 @@
     },
     {
         "name": "MonsterNameVaporeon",
-        "category": "MonsterCategoryVaporeon",
+        "category": "MonsterCategoryBubbleJet",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6511,7 +6511,7 @@
     },
     {
         "name": "MonsterNameJolteon",
-        "category": "MonsterCategoryJolteon",
+        "category": "MonsterCategoryLightning",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6561,7 +6561,7 @@
     },
     {
         "name": "MonsterNameFlareon",
-        "category": "MonsterCategoryCharmeleon",
+        "category": "MonsterCategoryFlame",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6612,7 +6612,7 @@
     },
     {
         "name": "MonsterNamePorygon",
-        "category": "MonsterCategoryPorygon",
+        "category": "MonsterCategoryVirtual",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6656,7 +6656,7 @@
     },
     {
         "name": "MonsterNameOmanyte",
-        "category": "MonsterCategoryOmanyte",
+        "category": "MonsterCategorySpiral",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6702,7 +6702,7 @@
     },
     {
         "name": "MonsterNameOmastar",
-        "category": "MonsterCategoryOmanyte",
+        "category": "MonsterCategorySpiral",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6755,7 +6755,7 @@
     },
     {
         "name": "MonsterNameKabuto",
-        "category": "MonsterCategoryBlastoise",
+        "category": "MonsterCategoryShellfish",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6801,7 +6801,7 @@
     },
     {
         "name": "MonsterNameKabutops",
-        "category": "MonsterCategoryBlastoise",
+        "category": "MonsterCategoryShellfish",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6854,7 +6854,7 @@
     },
     {
         "name": "MonsterNameAerodactyl",
-        "category": "MonsterCategoryAerodactyl",
+        "category": "MonsterCategoryFossil",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6900,7 +6900,7 @@
     },
     {
         "name": "MonsterNameSnorlax",
-        "category": "MonsterCategorySnorlax",
+        "category": "MonsterCategorySleeping",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -6951,7 +6951,7 @@
     },
     {
         "name": "MonsterNameArticuno",
-        "category": "MonsterCategoryArticuno",
+        "category": "MonsterCategoryFreeze",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -6998,7 +6998,7 @@
     },
     {
         "name": "MonsterNameZapdos",
-        "category": "MonsterCategoryElectabuzz",
+        "category": "MonsterCategoryElectric",
         "overworldPalette": 4,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -7045,7 +7045,7 @@
     },
     {
         "name": "MonsterNameMoltres",
-        "category": "MonsterCategoryCharmeleon",
+        "category": "MonsterCategoryFlame",
         "overworldPalette": 0,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -7092,7 +7092,7 @@
     },
     {
         "name": "MonsterNameDratini",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7136,7 +7136,7 @@
     },
     {
         "name": "MonsterNameDragonair",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7187,7 +7187,7 @@
     },
     {
         "name": "MonsterNameDragonite",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 8,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -7239,7 +7239,7 @@
     },
     {
         "name": "MonsterNameMewtwo",
-        "category": "MonsterCategoryMewtwo",
+        "category": "MonsterCategoryNewSpeciestwo",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7283,7 +7283,7 @@
     },
     {
         "name": "MonsterNameMew",
-        "category": "MonsterCategoryMew",
+        "category": "MonsterCategoryNewSpecies",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7327,7 +7327,7 @@
     },
     {
         "name": "MonsterNameChikorita",
-        "category": "MonsterCategoryChikorita",
+        "category": "MonsterCategoryLeaf",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7371,7 +7371,7 @@
     },
     {
         "name": "MonsterNameBayleef",
-        "category": "MonsterCategoryChikorita",
+        "category": "MonsterCategoryLeaf",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7421,7 +7421,7 @@
     },
     {
         "name": "MonsterNameMeganium",
-        "category": "MonsterCategoryMeganium",
+        "category": "MonsterCategoryHerb",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7471,7 +7471,7 @@
     },
     {
         "name": "MonsterNameCyndaquil",
-        "category": "MonsterCategoryCyndaquil",
+        "category": "MonsterCategoryFireMouse",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7516,7 +7516,7 @@
     },
     {
         "name": "MonsterNameQuilava",
-        "category": "MonsterCategoryQuilava",
+        "category": "MonsterCategoryVolcano",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7567,7 +7567,7 @@
     },
     {
         "name": "MonsterNameTyphlosion",
-        "category": "MonsterCategoryQuilava",
+        "category": "MonsterCategoryVolcano",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7618,7 +7618,7 @@
     },
     {
         "name": "MonsterNameTotodile",
-        "category": "MonsterCategoryTotodile",
+        "category": "MonsterCategoryBigJaw",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7663,7 +7663,7 @@
     },
     {
         "name": "MonsterNameCroconaw",
-        "category": "MonsterCategoryTotodile",
+        "category": "MonsterCategoryBigJaw",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7714,7 +7714,7 @@
     },
     {
         "name": "MonsterNameFeraligatr",
-        "category": "MonsterCategoryTotodile",
+        "category": "MonsterCategoryBigJaw",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7765,7 +7765,7 @@
     },
     {
         "name": "MonsterNameSentret",
-        "category": "MonsterCategorySentret",
+        "category": "MonsterCategoryScout",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7809,7 +7809,7 @@
     },
     {
         "name": "MonsterNameFurret",
-        "category": "MonsterCategoryFurret",
+        "category": "MonsterCategoryLongBody",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7860,7 +7860,7 @@
     },
     {
         "name": "MonsterNameHoothoot",
-        "category": "MonsterCategoryHoothoot",
+        "category": "MonsterCategoryOwl",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7905,7 +7905,7 @@
     },
     {
         "name": "MonsterNameNoctowl",
-        "category": "MonsterCategoryHoothoot",
+        "category": "MonsterCategoryOwl",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -7957,7 +7957,7 @@
     },
     {
         "name": "MonsterNameLedyba",
-        "category": "MonsterCategoryLedyba",
+        "category": "MonsterCategoryFiveStar",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8003,7 +8003,7 @@
     },
     {
         "name": "MonsterNameLedian",
-        "category": "MonsterCategoryLedyba",
+        "category": "MonsterCategoryFiveStar",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8056,7 +8056,7 @@
     },
     {
         "name": "MonsterNameSpinarak",
-        "category": "MonsterCategorySpinarak",
+        "category": "MonsterCategoryStringSpit",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8101,7 +8101,7 @@
     },
     {
         "name": "MonsterNameAriados",
-        "category": "MonsterCategoryAriados",
+        "category": "MonsterCategoryLongLeg",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8153,7 +8153,7 @@
     },
     {
         "name": "MonsterNameCrobat",
-        "category": "MonsterCategoryZubat",
+        "category": "MonsterCategoryBat",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8205,7 +8205,7 @@
     },
     {
         "name": "MonsterNameChinchou",
-        "category": "MonsterCategoryChinchou",
+        "category": "MonsterCategoryAngler",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8251,7 +8251,7 @@
     },
     {
         "name": "MonsterNameLanturn",
-        "category": "MonsterCategoryLanturn",
+        "category": "MonsterCategoryLight",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8304,7 +8304,7 @@
     },
     {
         "name": "MonsterNamePichu",
-        "category": "MonsterCategoryPichu",
+        "category": "MonsterCategoryTinyMouse",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8347,7 +8347,7 @@
     },
     {
         "name": "MonsterNameCleffa",
-        "category": "MonsterCategoryStaryu",
+        "category": "MonsterCategoryStarShape",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8390,7 +8390,7 @@
     },
     {
         "name": "MonsterNameIgglybuff",
-        "category": "MonsterCategoryJigglypuff",
+        "category": "MonsterCategoryBalloon",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8433,7 +8433,7 @@
     },
     {
         "name": "MonsterNameTogepi",
-        "category": "MonsterCategoryTogepi",
+        "category": "MonsterCategorySpikeBall",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8477,7 +8477,7 @@
     },
     {
         "name": "MonsterNameTogetic",
-        "category": "MonsterCategoryTogetic",
+        "category": "MonsterCategoryHappiness",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8529,7 +8529,7 @@
     },
     {
         "name": "MonsterNameNatu",
-        "category": "MonsterCategoryPidgey",
+        "category": "MonsterCategoryTinyBird",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8574,7 +8574,7 @@
     },
     {
         "name": "MonsterNameXatu",
-        "category": "MonsterCategoryXatu",
+        "category": "MonsterCategoryMystic",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8627,7 +8627,7 @@
     },
     {
         "name": "MonsterNameMareep",
-        "category": "MonsterCategoryMareep",
+        "category": "MonsterCategoryWool",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8670,7 +8670,7 @@
     },
     {
         "name": "MonsterNameFlaaffy",
-        "category": "MonsterCategoryMareep",
+        "category": "MonsterCategoryWool",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8720,7 +8720,7 @@
     },
     {
         "name": "MonsterNameAmpharos",
-        "category": "MonsterCategoryLanturn",
+        "category": "MonsterCategoryLight",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8770,7 +8770,7 @@
     },
     {
         "name": "MonsterNameBellossom",
-        "category": "MonsterCategoryVileplume",
+        "category": "MonsterCategoryFlower",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8820,7 +8820,7 @@
     },
     {
         "name": "MonsterNameMarill",
-        "category": "MonsterCategoryMarill",
+        "category": "MonsterCategoryAquaMouse",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8872,7 +8872,7 @@
     },
     {
         "name": "MonsterNameAzumarill",
-        "category": "MonsterCategoryAzumarill",
+        "category": "MonsterCategoryAquaRabbit",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8924,7 +8924,7 @@
     },
     {
         "name": "MonsterNameSudowoodo",
-        "category": "MonsterCategorySudowoodo",
+        "category": "MonsterCategoryImitation",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -8968,7 +8968,7 @@
     },
     {
         "name": "MonsterNamePolitoed",
-        "category": "MonsterCategoryPolitoed",
+        "category": "MonsterCategoryFrog",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9021,7 +9021,7 @@
     },
     {
         "name": "MonsterNameHoppip",
-        "category": "MonsterCategoryHoppip",
+        "category": "MonsterCategoryCottonweed",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9065,7 +9065,7 @@
     },
     {
         "name": "MonsterNameSkiploom",
-        "category": "MonsterCategoryHoppip",
+        "category": "MonsterCategoryCottonweed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9116,7 +9116,7 @@
     },
     {
         "name": "MonsterNameJumpluff",
-        "category": "MonsterCategoryHoppip",
+        "category": "MonsterCategoryCottonweed",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9168,7 +9168,7 @@
     },
     {
         "name": "MonsterNameAipom",
-        "category": "MonsterCategoryAipom",
+        "category": "MonsterCategoryLongTail",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9212,7 +9212,7 @@
     },
     {
         "name": "MonsterNameSunkern",
-        "category": "MonsterCategoryBulbasaur",
+        "category": "MonsterCategorySeed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9255,7 +9255,7 @@
     },
     {
         "name": "MonsterNameSunflora",
-        "category": "MonsterCategorySunflora",
+        "category": "MonsterCategorySun",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9305,7 +9305,7 @@
     },
     {
         "name": "MonsterNameYanma",
-        "category": "MonsterCategoryYanma",
+        "category": "MonsterCategoryClearWing",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9351,7 +9351,7 @@
     },
     {
         "name": "MonsterNameWooper",
-        "category": "MonsterCategoryWooper",
+        "category": "MonsterCategoryWaterFish",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9397,7 +9397,7 @@
     },
     {
         "name": "MonsterNameQuagsire",
-        "category": "MonsterCategoryWooper",
+        "category": "MonsterCategoryWaterFish",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9450,7 +9450,7 @@
     },
     {
         "name": "MonsterNameEspeon",
-        "category": "MonsterCategorySunflora",
+        "category": "MonsterCategorySun",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9501,7 +9501,7 @@
     },
     {
         "name": "MonsterNameUmbreon",
-        "category": "MonsterCategoryUmbreon",
+        "category": "MonsterCategoryMoonlight",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9552,7 +9552,7 @@
     },
     {
         "name": "MonsterNameMurkrow",
-        "category": "MonsterCategoryMurkrow",
+        "category": "MonsterCategoryDarkness",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9596,7 +9596,7 @@
     },
     {
         "name": "MonsterNameSlowking",
-        "category": "MonsterCategorySlowking",
+        "category": "MonsterCategoryRoyal",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9650,7 +9650,7 @@
     },
     {
         "name": "MonsterNameMisdreavus",
-        "category": "MonsterCategoryMisdreavus",
+        "category": "MonsterCategoryScreech",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9694,7 +9694,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9738,7 +9738,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9782,7 +9782,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9826,7 +9826,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9870,7 +9870,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9914,7 +9914,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -9958,7 +9958,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10002,7 +10002,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10046,7 +10046,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10090,7 +10090,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10134,7 +10134,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10178,7 +10178,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10222,7 +10222,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10266,7 +10266,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10310,7 +10310,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10354,7 +10354,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10398,7 +10398,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10442,7 +10442,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10486,7 +10486,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10530,7 +10530,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10574,7 +10574,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10618,7 +10618,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10662,7 +10662,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10706,7 +10706,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10750,7 +10750,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10794,7 +10794,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10838,7 +10838,7 @@
     },
     {
         "name": "MonsterNameWobbuffet",
-        "category": "MonsterCategoryWobbuffet",
+        "category": "MonsterCategoryPatient",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10889,7 +10889,7 @@
     },
     {
         "name": "MonsterNameGirafarig",
-        "category": "MonsterCategoryGirafarig",
+        "category": "MonsterCategoryLongNeck",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10934,7 +10934,7 @@
     },
     {
         "name": "MonsterNamePineco",
-        "category": "MonsterCategoryPineco",
+        "category": "MonsterCategoryBagworm",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -10977,7 +10977,7 @@
     },
     {
         "name": "MonsterNameForretress",
-        "category": "MonsterCategoryPineco",
+        "category": "MonsterCategoryBagworm",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11028,7 +11028,7 @@
     },
     {
         "name": "MonsterNameDunsparce",
-        "category": "MonsterCategoryDunsparce",
+        "category": "MonsterCategoryLandSnake",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11072,7 +11072,7 @@
     },
     {
         "name": "MonsterNameGligar",
-        "category": "MonsterCategoryGligar",
+        "category": "MonsterCategoryFlyscorpion",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11118,7 +11118,7 @@
     },
     {
         "name": "MonsterNameSteelix",
-        "category": "MonsterCategorySteelix",
+        "category": "MonsterCategoryIronSnake",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -11171,7 +11171,7 @@
     },
     {
         "name": "MonsterNameSnubbull",
-        "category": "MonsterCategoryClefairy",
+        "category": "MonsterCategoryFairy",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11216,7 +11216,7 @@
     },
     {
         "name": "MonsterNameGranbull",
-        "category": "MonsterCategoryClefairy",
+        "category": "MonsterCategoryFairy",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11267,7 +11267,7 @@
     },
     {
         "name": "MonsterNameQwilfish",
-        "category": "MonsterCategoryJigglypuff",
+        "category": "MonsterCategoryBalloon",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11313,7 +11313,7 @@
     },
     {
         "name": "MonsterNameScizor",
-        "category": "MonsterCategoryKingler",
+        "category": "MonsterCategoryPincer",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11365,7 +11365,7 @@
     },
     {
         "name": "MonsterNameShuckle",
-        "category": "MonsterCategoryShuckle",
+        "category": "MonsterCategoryMold",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11409,7 +11409,7 @@
     },
     {
         "name": "MonsterNameHeracross",
-        "category": "MonsterCategoryHeracross",
+        "category": "MonsterCategorySingleHorn",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11454,7 +11454,7 @@
     },
     {
         "name": "MonsterNameSneasel",
-        "category": "MonsterCategorySneasel",
+        "category": "MonsterCategorySharpClaw",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11499,7 +11499,7 @@
     },
     {
         "name": "MonsterNameTeddiursa",
-        "category": "MonsterCategoryTeddiursa",
+        "category": "MonsterCategoryLittleBear",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11542,7 +11542,7 @@
     },
     {
         "name": "MonsterNameUrsaring",
-        "category": "MonsterCategoryUrsaring",
+        "category": "MonsterCategoryHibernator",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11592,7 +11592,7 @@
     },
     {
         "name": "MonsterNameSlugma",
-        "category": "MonsterCategorySlugma",
+        "category": "MonsterCategoryLava",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11637,7 +11637,7 @@
     },
     {
         "name": "MonsterNameMagcargo",
-        "category": "MonsterCategorySlugma",
+        "category": "MonsterCategoryLava",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11690,7 +11690,7 @@
     },
     {
         "name": "MonsterNameSwinub",
-        "category": "MonsterCategorySwinub",
+        "category": "MonsterCategoryPig",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11734,7 +11734,7 @@
     },
     {
         "name": "MonsterNamePiloswine",
-        "category": "MonsterCategoryPiloswine",
+        "category": "MonsterCategorySwine",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11785,7 +11785,7 @@
     },
     {
         "name": "MonsterNameCorsola",
-        "category": "MonsterCategoryCorsola",
+        "category": "MonsterCategoryCoral",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11831,7 +11831,7 @@
     },
     {
         "name": "MonsterNameRemoraid",
-        "category": "MonsterCategoryRemoraid",
+        "category": "MonsterCategoryJet",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11875,7 +11875,7 @@
     },
     {
         "name": "MonsterNameOctillery",
-        "category": "MonsterCategoryRemoraid",
+        "category": "MonsterCategoryJet",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11927,7 +11927,7 @@
     },
     {
         "name": "MonsterNameDelibird",
-        "category": "MonsterCategoryDelibird",
+        "category": "MonsterCategoryDelivery",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -11972,7 +11972,7 @@
     },
     {
         "name": "MonsterNameMantine",
-        "category": "MonsterCategoryMantine",
+        "category": "MonsterCategoryKite",
         "overworldPalette": 7,
         "bodySize": 2,
         "movementSpeed": 1,
@@ -12018,7 +12018,7 @@
     },
     {
         "name": "MonsterNameSkarmory",
-        "category": "MonsterCategorySkarmory",
+        "category": "MonsterCategoryArmorBird",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12064,7 +12064,7 @@
     },
     {
         "name": "MonsterNameHoundour",
-        "category": "MonsterCategoryHoundour",
+        "category": "MonsterCategoryDark",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12110,7 +12110,7 @@
     },
     {
         "name": "MonsterNameHoundoom",
-        "category": "MonsterCategoryHoundour",
+        "category": "MonsterCategoryDark",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12163,7 +12163,7 @@
     },
     {
         "name": "MonsterNameKingdra",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12216,7 +12216,7 @@
     },
     {
         "name": "MonsterNamePhanpy",
-        "category": "MonsterCategoryPhanpy",
+        "category": "MonsterCategoryLongNose",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12259,7 +12259,7 @@
     },
     {
         "name": "MonsterNameDonphan",
-        "category": "MonsterCategoryDonphan",
+        "category": "MonsterCategoryArmor",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12309,7 +12309,7 @@
     },
     {
         "name": "MonsterNamePorygon2",
-        "category": "MonsterCategoryPorygon",
+        "category": "MonsterCategoryVirtual",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12361,7 +12361,7 @@
     },
     {
         "name": "MonsterNameStantler",
-        "category": "MonsterCategoryStantler",
+        "category": "MonsterCategoryBigHorn",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12404,7 +12404,7 @@
     },
     {
         "name": "MonsterNameSmeargle",
-        "category": "MonsterCategorySmeargle",
+        "category": "MonsterCategoryPainter",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12448,7 +12448,7 @@
     },
     {
         "name": "MonsterNameTyrogue",
-        "category": "MonsterCategoryTyrogue",
+        "category": "MonsterCategoryScuffle",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12491,7 +12491,7 @@
     },
     {
         "name": "MonsterNameHitmontop",
-        "category": "MonsterCategoryHitmontop",
+        "category": "MonsterCategoryHandstand",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12542,7 +12542,7 @@
     },
     {
         "name": "MonsterNameSmoochum",
-        "category": "MonsterCategorySmoochum",
+        "category": "MonsterCategoryKiss",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12586,7 +12586,7 @@
     },
     {
         "name": "MonsterNameElekid",
-        "category": "MonsterCategoryElectabuzz",
+        "category": "MonsterCategoryElectric",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12629,7 +12629,7 @@
     },
     {
         "name": "MonsterNameMagby",
-        "category": "MonsterCategoryMagby",
+        "category": "MonsterCategoryLiveCoal",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12673,7 +12673,7 @@
     },
     {
         "name": "MonsterNameMiltank",
-        "category": "MonsterCategoryMiltank",
+        "category": "MonsterCategoryMilkCow",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12716,7 +12716,7 @@
     },
     {
         "name": "MonsterNameBlissey",
-        "category": "MonsterCategoryTogetic",
+        "category": "MonsterCategoryHappiness",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12767,7 +12767,7 @@
     },
     {
         "name": "MonsterNameRaikou",
-        "category": "MonsterCategoryRaikou",
+        "category": "MonsterCategoryThunder",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12811,7 +12811,7 @@
     },
     {
         "name": "MonsterNameEntei",
-        "category": "MonsterCategoryQuilava",
+        "category": "MonsterCategoryVolcano",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12856,7 +12856,7 @@
     },
     {
         "name": "MonsterNameSuicune",
-        "category": "MonsterCategorySuicune",
+        "category": "MonsterCategoryAurora",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12901,7 +12901,7 @@
     },
     {
         "name": "MonsterNameLarvitar",
-        "category": "MonsterCategoryLarvitar",
+        "category": "MonsterCategoryRockSkin",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12945,7 +12945,7 @@
     },
     {
         "name": "MonsterNamePupitar",
-        "category": "MonsterCategoryPupitar",
+        "category": "MonsterCategoryHardShell",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -12996,7 +12996,7 @@
     },
     {
         "name": "MonsterNameTyranitar",
-        "category": "MonsterCategoryDonphan",
+        "category": "MonsterCategoryArmor",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13048,7 +13048,7 @@
     },
     {
         "name": "MonsterNameLugia",
-        "category": "MonsterCategoryLugia",
+        "category": "MonsterCategoryDiving",
         "overworldPalette": 9,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -13095,7 +13095,7 @@
     },
     {
         "name": "MonsterNameHoOh",
-        "category": "MonsterCategoryHoOh",
+        "category": "MonsterCategoryRainbow",
         "overworldPalette": 3,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -13141,7 +13141,7 @@
     },
     {
         "name": "MonsterNameCelebi",
-        "category": "MonsterCategoryCelebi",
+        "category": "MonsterCategoryTimeTravel",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13187,7 +13187,7 @@
     },
     {
         "name": "MonsterNameTreecko",
-        "category": "MonsterCategoryTreecko",
+        "category": "MonsterCategoryWoodGecko",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13231,7 +13231,7 @@
     },
     {
         "name": "MonsterNameGrovyle",
-        "category": "MonsterCategoryTreecko",
+        "category": "MonsterCategoryWoodGecko",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13281,7 +13281,7 @@
     },
     {
         "name": "MonsterNameSceptile",
-        "category": "MonsterCategorySceptile",
+        "category": "MonsterCategoryForest",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13331,7 +13331,7 @@
     },
     {
         "name": "MonsterNameTorchic",
-        "category": "MonsterCategoryTorchic",
+        "category": "MonsterCategoryChick",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13376,7 +13376,7 @@
     },
     {
         "name": "MonsterNameCombusken",
-        "category": "MonsterCategoryCombusken",
+        "category": "MonsterCategoryYoungFowl",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13428,7 +13428,7 @@
     },
     {
         "name": "MonsterNameBlaziken",
-        "category": "MonsterCategoryBlaziken",
+        "category": "MonsterCategoryBlaze",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13480,7 +13480,7 @@
     },
     {
         "name": "MonsterNameMudkip",
-        "category": "MonsterCategoryMudkip",
+        "category": "MonsterCategoryMudFish",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13525,7 +13525,7 @@
     },
     {
         "name": "MonsterNameMarshtomp",
-        "category": "MonsterCategoryMudkip",
+        "category": "MonsterCategoryMudFish",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13577,7 +13577,7 @@
     },
     {
         "name": "MonsterNameSwampert",
-        "category": "MonsterCategoryMudkip",
+        "category": "MonsterCategoryMudFish",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13629,7 +13629,7 @@
     },
     {
         "name": "MonsterNamePoochyena",
-        "category": "MonsterCategoryPoochyena",
+        "category": "MonsterCategoryBite",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13672,7 +13672,7 @@
     },
     {
         "name": "MonsterNameMightyena",
-        "category": "MonsterCategoryPoochyena",
+        "category": "MonsterCategoryBite",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13722,7 +13722,7 @@
     },
     {
         "name": "MonsterNameZigzagoon",
-        "category": "MonsterCategoryZigzagoon",
+        "category": "MonsterCategoryTinyraccoon",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13765,7 +13765,7 @@
     },
     {
         "name": "MonsterNameLinoone",
-        "category": "MonsterCategoryLinoone",
+        "category": "MonsterCategoryRushing",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13815,7 +13815,7 @@
     },
     {
         "name": "MonsterNameWurmple",
-        "category": "MonsterCategoryCaterpie",
+        "category": "MonsterCategoryWorm",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13858,7 +13858,7 @@
     },
     {
         "name": "MonsterNameSilcoon",
-        "category": "MonsterCategoryMetapod",
+        "category": "MonsterCategoryCocoon",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13909,7 +13909,7 @@
     },
     {
         "name": "MonsterNameBeautifly",
-        "category": "MonsterCategoryButterfree",
+        "category": "MonsterCategoryButterfly",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -13961,7 +13961,7 @@
     },
     {
         "name": "MonsterNameCascoon",
-        "category": "MonsterCategoryMetapod",
+        "category": "MonsterCategoryCocoon",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14012,7 +14012,7 @@
     },
     {
         "name": "MonsterNameDustox",
-        "category": "MonsterCategoryVenomoth",
+        "category": "MonsterCategoryPoisonMoth",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14064,7 +14064,7 @@
     },
     {
         "name": "MonsterNameLotad",
-        "category": "MonsterCategoryLotad",
+        "category": "MonsterCategoryWaterWeed",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14110,7 +14110,7 @@
     },
     {
         "name": "MonsterNameLombre",
-        "category": "MonsterCategoryLombre",
+        "category": "MonsterCategoryJolly",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14164,7 +14164,7 @@
     },
     {
         "name": "MonsterNameLudicolo",
-        "category": "MonsterCategoryLudicolo",
+        "category": "MonsterCategoryCarefree",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14217,7 +14217,7 @@
     },
     {
         "name": "MonsterNameSeedot",
-        "category": "MonsterCategorySeedot",
+        "category": "MonsterCategoryAcorn",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14261,7 +14261,7 @@
     },
     {
         "name": "MonsterNameNuzleaf",
-        "category": "MonsterCategoryNuzleaf",
+        "category": "MonsterCategoryWily",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14313,7 +14313,7 @@
     },
     {
         "name": "MonsterNameShiftry",
-        "category": "MonsterCategoryShiftry",
+        "category": "MonsterCategoryWicked",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14366,7 +14366,7 @@
     },
     {
         "name": "MonsterNameTaillow",
-        "category": "MonsterCategoryTaillow",
+        "category": "MonsterCategoryTinyswallow",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14410,7 +14410,7 @@
     },
     {
         "name": "MonsterNameSwellow",
-        "category": "MonsterCategorySwellow",
+        "category": "MonsterCategorySwallow",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14461,7 +14461,7 @@
     },
     {
         "name": "MonsterNameWingull",
-        "category": "MonsterCategoryWingull",
+        "category": "MonsterCategorySeagull",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14506,7 +14506,7 @@
     },
     {
         "name": "MonsterNamePelipper",
-        "category": "MonsterCategoryPelipper",
+        "category": "MonsterCategoryWaterBird",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14559,7 +14559,7 @@
     },
     {
         "name": "MonsterNameRalts",
-        "category": "MonsterCategoryRalts",
+        "category": "MonsterCategoryFeeling",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14603,7 +14603,7 @@
     },
     {
         "name": "MonsterNameKirlia",
-        "category": "MonsterCategoryKirlia",
+        "category": "MonsterCategoryEmotion",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14654,7 +14654,7 @@
     },
     {
         "name": "MonsterNameGardevoir",
-        "category": "MonsterCategoryGardevoir",
+        "category": "MonsterCategoryEmbrace",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14706,7 +14706,7 @@
     },
     {
         "name": "MonsterNameSurskit",
-        "category": "MonsterCategorySurskit",
+        "category": "MonsterCategoryPondSkater",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14751,7 +14751,7 @@
     },
     {
         "name": "MonsterNameMasquerain",
-        "category": "MonsterCategoryMasquerain",
+        "category": "MonsterCategoryEyeball",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14803,7 +14803,7 @@
     },
     {
         "name": "MonsterNameShroomish",
-        "category": "MonsterCategoryParas",
+        "category": "MonsterCategoryMushroom",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14846,7 +14846,7 @@
     },
     {
         "name": "MonsterNameBreloom",
-        "category": "MonsterCategoryParas",
+        "category": "MonsterCategoryMushroom",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14897,7 +14897,7 @@
     },
     {
         "name": "MonsterNameSlakoth",
-        "category": "MonsterCategorySlakoth",
+        "category": "MonsterCategorySlacker",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14940,7 +14940,7 @@
     },
     {
         "name": "MonsterNameVigoroth",
-        "category": "MonsterCategoryVigoroth",
+        "category": "MonsterCategoryWildMonkey",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -14990,7 +14990,7 @@
     },
     {
         "name": "MonsterNameSlaking",
-        "category": "MonsterCategorySlaking",
+        "category": "MonsterCategoryLazy",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15040,7 +15040,7 @@
     },
     {
         "name": "MonsterNameNincada",
-        "category": "MonsterCategoryNincada",
+        "category": "MonsterCategoryTrainee",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15084,7 +15084,7 @@
     },
     {
         "name": "MonsterNameNinjask",
-        "category": "MonsterCategoryNinjask",
+        "category": "MonsterCategoryNinja",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15136,7 +15136,7 @@
     },
     {
         "name": "MonsterNameShedinja",
-        "category": "MonsterCategoryShedinja",
+        "category": "MonsterCategoryShed",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15188,7 +15188,7 @@
     },
     {
         "name": "MonsterNameWhismur",
-        "category": "MonsterCategoryWhismur",
+        "category": "MonsterCategoryWhisper",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15231,7 +15231,7 @@
     },
     {
         "name": "MonsterNameLoudred",
-        "category": "MonsterCategoryLoudred",
+        "category": "MonsterCategoryBigVoice",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15281,7 +15281,7 @@
     },
     {
         "name": "MonsterNameExploud",
-        "category": "MonsterCategoryExploud",
+        "category": "MonsterCategoryLoudNoise",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15331,7 +15331,7 @@
     },
     {
         "name": "MonsterNameMakuhita",
-        "category": "MonsterCategoryMakuhita",
+        "category": "MonsterCategoryGuts",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15376,7 +15376,7 @@
     },
     {
         "name": "MonsterNameHariyama",
-        "category": "MonsterCategoryHariyama",
+        "category": "MonsterCategoryArmThrust",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15427,7 +15427,7 @@
     },
     {
         "name": "MonsterNameAzurill",
-        "category": "MonsterCategoryAzurill",
+        "category": "MonsterCategoryPolkaDot",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15472,7 +15472,7 @@
     },
     {
         "name": "MonsterNameNosepass",
-        "category": "MonsterCategoryNosepass",
+        "category": "MonsterCategoryCompass",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15516,7 +15516,7 @@
     },
     {
         "name": "MonsterNameSkitty",
-        "category": "MonsterCategorySkitty",
+        "category": "MonsterCategoryKitten",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15560,7 +15560,7 @@
     },
     {
         "name": "MonsterNameDelcatty",
-        "category": "MonsterCategoryDelcatty",
+        "category": "MonsterCategoryPrim",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15610,7 +15610,7 @@
     },
     {
         "name": "MonsterNameSableye",
-        "category": "MonsterCategoryMurkrow",
+        "category": "MonsterCategoryDarkness",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15654,7 +15654,7 @@
     },
     {
         "name": "MonsterNameMawile",
-        "category": "MonsterCategoryMawile",
+        "category": "MonsterCategoryDeceiver",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15698,7 +15698,7 @@
     },
     {
         "name": "MonsterNameAron",
-        "category": "MonsterCategoryAron",
+        "category": "MonsterCategoryIronArmor",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15743,7 +15743,7 @@
     },
     {
         "name": "MonsterNameLairon",
-        "category": "MonsterCategoryAron",
+        "category": "MonsterCategoryIronArmor",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15795,7 +15795,7 @@
     },
     {
         "name": "MonsterNameAggron",
-        "category": "MonsterCategoryAron",
+        "category": "MonsterCategoryIronArmor",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15847,7 +15847,7 @@
     },
     {
         "name": "MonsterNameMeditite",
-        "category": "MonsterCategoryMeditite",
+        "category": "MonsterCategoryMeditate",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15892,7 +15892,7 @@
     },
     {
         "name": "MonsterNameMedicham",
-        "category": "MonsterCategoryMeditite",
+        "category": "MonsterCategoryMeditate",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15944,7 +15944,7 @@
     },
     {
         "name": "MonsterNameElectrike",
-        "category": "MonsterCategoryJolteon",
+        "category": "MonsterCategoryLightning",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -15988,7 +15988,7 @@
     },
     {
         "name": "MonsterNameManectric",
-        "category": "MonsterCategoryManectric",
+        "category": "MonsterCategoryDischarge",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16039,7 +16039,7 @@
     },
     {
         "name": "MonsterNamePlusle",
-        "category": "MonsterCategoryPlusle",
+        "category": "MonsterCategoryCheering",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16082,7 +16082,7 @@
     },
     {
         "name": "MonsterNameMinun",
-        "category": "MonsterCategoryPlusle",
+        "category": "MonsterCategoryCheering",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16125,7 +16125,7 @@
     },
     {
         "name": "MonsterNameVolbeat",
-        "category": "MonsterCategoryVolbeat",
+        "category": "MonsterCategoryFirefly",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16169,7 +16169,7 @@
     },
     {
         "name": "MonsterNameIllumise",
-        "category": "MonsterCategoryVolbeat",
+        "category": "MonsterCategoryFirefly",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16212,7 +16212,7 @@
     },
     {
         "name": "MonsterNameRoselia",
-        "category": "MonsterCategoryRoselia",
+        "category": "MonsterCategoryThorn",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16257,7 +16257,7 @@
     },
     {
         "name": "MonsterNameGulpin",
-        "category": "MonsterCategoryGulpin",
+        "category": "MonsterCategoryStomach",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16302,7 +16302,7 @@
     },
     {
         "name": "MonsterNameSwalot",
-        "category": "MonsterCategorySwalot",
+        "category": "MonsterCategoryPoisonBag",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16353,7 +16353,7 @@
     },
     {
         "name": "MonsterNameCarvanha",
-        "category": "MonsterCategoryCarvanha",
+        "category": "MonsterCategorySavage",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16398,7 +16398,7 @@
     },
     {
         "name": "MonsterNameSharpedo",
-        "category": "MonsterCategorySharpedo",
+        "category": "MonsterCategoryBrutal",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16450,7 +16450,7 @@
     },
     {
         "name": "MonsterNameWailmer",
-        "category": "MonsterCategoryWailmer",
+        "category": "MonsterCategoryBallWhale",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16495,7 +16495,7 @@
     },
     {
         "name": "MonsterNameWailord",
-        "category": "MonsterCategoryWailord",
+        "category": "MonsterCategoryFloatWhale",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -16547,7 +16547,7 @@
     },
     {
         "name": "MonsterNameNumel",
-        "category": "MonsterCategoryNumel",
+        "category": "MonsterCategoryNumb",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16592,7 +16592,7 @@
     },
     {
         "name": "MonsterNameCamerupt",
-        "category": "MonsterCategoryNone",
+        "category": "MonsterCategoryEruption",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16644,7 +16644,7 @@
     },
     {
         "name": "MonsterNameTorkoal",
-        "category": "MonsterCategoryTorkoal",
+        "category": "MonsterCategoryCoal",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16688,7 +16688,7 @@
     },
     {
         "name": "MonsterNameSpoink",
-        "category": "MonsterCategorySpoink",
+        "category": "MonsterCategoryBounce",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16732,7 +16732,7 @@
     },
     {
         "name": "MonsterNameGrumpig",
-        "category": "MonsterCategoryGrumpig",
+        "category": "MonsterCategoryManipulate",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16783,7 +16783,7 @@
     },
     {
         "name": "MonsterNameSpinda",
-        "category": "MonsterCategorySpinda",
+        "category": "MonsterCategorySpotPanda",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16827,7 +16827,7 @@
     },
     {
         "name": "MonsterNameTrapinch",
-        "category": "MonsterCategoryTrapinch",
+        "category": "MonsterCategoryAntPit",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16871,7 +16871,7 @@
     },
     {
         "name": "MonsterNameVibrava",
-        "category": "MonsterCategoryVibrava",
+        "category": "MonsterCategoryVibration",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16923,7 +16923,7 @@
     },
     {
         "name": "MonsterNameFlygon",
-        "category": "MonsterCategoryXatu",
+        "category": "MonsterCategoryMystic",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -16975,7 +16975,7 @@
     },
     {
         "name": "MonsterNameCacnea",
-        "category": "MonsterCategoryCacnea",
+        "category": "MonsterCategoryCactus",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17018,7 +17018,7 @@
     },
     {
         "name": "MonsterNameCacturne",
-        "category": "MonsterCategoryCacturne",
+        "category": "MonsterCategoryScarecrow",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17069,7 +17069,7 @@
     },
     {
         "name": "MonsterNameSwablu",
-        "category": "MonsterCategorySwablu",
+        "category": "MonsterCategoryCottonBird",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17114,7 +17114,7 @@
     },
     {
         "name": "MonsterNameAltaria",
-        "category": "MonsterCategoryAltaria",
+        "category": "MonsterCategoryHumming",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17165,7 +17165,7 @@
     },
     {
         "name": "MonsterNameZangoose",
-        "category": "MonsterCategoryZangoose",
+        "category": "MonsterCategoryCatFerret",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17208,7 +17208,7 @@
     },
     {
         "name": "MonsterNameSeviper",
-        "category": "MonsterCategorySeviper",
+        "category": "MonsterCategoryFangSnake",
         "overworldPalette": 2,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17251,7 +17251,7 @@
     },
     {
         "name": "MonsterNameLunatone",
-        "category": "MonsterCategoryLunatone",
+        "category": "MonsterCategoryMeteorite",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17296,7 +17296,7 @@
     },
     {
         "name": "MonsterNameSolrock",
-        "category": "MonsterCategoryLunatone",
+        "category": "MonsterCategoryMeteorite",
         "overworldPalette": 4,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17341,7 +17341,7 @@
     },
     {
         "name": "MonsterNameBarboach",
-        "category": "MonsterCategoryBarboach",
+        "category": "MonsterCategoryWhiskers",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17386,7 +17386,7 @@
     },
     {
         "name": "MonsterNameWhiscash",
-        "category": "MonsterCategoryBarboach",
+        "category": "MonsterCategoryWhiskers",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17439,7 +17439,7 @@
     },
     {
         "name": "MonsterNameCorphish",
-        "category": "MonsterCategoryCorphish",
+        "category": "MonsterCategoryRuffian",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17484,7 +17484,7 @@
     },
     {
         "name": "MonsterNameCrawdaunt",
-        "category": "MonsterCategoryCrawdaunt",
+        "category": "MonsterCategoryRogue",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17537,7 +17537,7 @@
     },
     {
         "name": "MonsterNameBaltoy",
-        "category": "MonsterCategoryBaltoy",
+        "category": "MonsterCategoryClayDoll",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17582,7 +17582,7 @@
     },
     {
         "name": "MonsterNameClaydol",
-        "category": "MonsterCategoryBaltoy",
+        "category": "MonsterCategoryClayDoll",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17634,7 +17634,7 @@
     },
     {
         "name": "MonsterNameLileep",
-        "category": "MonsterCategoryLileep",
+        "category": "MonsterCategorySeaLily",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17678,7 +17678,7 @@
     },
     {
         "name": "MonsterNameCradily",
-        "category": "MonsterCategoryCradily",
+        "category": "MonsterCategoryBarnacle",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17729,7 +17729,7 @@
     },
     {
         "name": "MonsterNameAnorith",
-        "category": "MonsterCategoryAnorith",
+        "category": "MonsterCategoryOldShrimp",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17773,7 +17773,7 @@
     },
     {
         "name": "MonsterNameArmaldo",
-        "category": "MonsterCategoryArmaldo",
+        "category": "MonsterCategoryPlate",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17824,7 +17824,7 @@
     },
     {
         "name": "MonsterNameFeebas",
-        "category": "MonsterCategoryMagikarp",
+        "category": "MonsterCategoryFish",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17868,7 +17868,7 @@
     },
     {
         "name": "MonsterNameMilotic",
-        "category": "MonsterCategoryMilotic",
+        "category": "MonsterCategoryTender",
         "overworldPalette": 0,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -17920,7 +17920,7 @@
     },
     {
         "name": "MonsterNameCastform",
-        "category": "MonsterCategoryCastform",
+        "category": "MonsterCategoryWeather",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -17963,7 +17963,7 @@
     },
     {
         "name": "MonsterNameCastform",
-        "category": "MonsterCategoryCastform",
+        "category": "MonsterCategoryWeather",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18006,7 +18006,7 @@
     },
     {
         "name": "MonsterNameCastform",
-        "category": "MonsterCategoryCastform",
+        "category": "MonsterCategoryWeather",
         "overworldPalette": 0,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18049,7 +18049,7 @@
     },
     {
         "name": "MonsterNameCastform",
-        "category": "MonsterCategoryCastform",
+        "category": "MonsterCategoryWeather",
         "overworldPalette": 7,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18092,7 +18092,7 @@
     },
     {
         "name": "MonsterNameKecleon",
-        "category": "MonsterCategoryKecleon",
+        "category": "MonsterCategoryColorSwap",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18136,7 +18136,7 @@
     },
     {
         "name": "MonsterNameShuppet",
-        "category": "MonsterCategoryShuppet",
+        "category": "MonsterCategoryPuppet",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18180,7 +18180,7 @@
     },
     {
         "name": "MonsterNameBanette",
-        "category": "MonsterCategoryBanette",
+        "category": "MonsterCategoryMarionette",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18231,7 +18231,7 @@
     },
     {
         "name": "MonsterNameDuskull",
-        "category": "MonsterCategoryDuskull",
+        "category": "MonsterCategoryRequiem",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18275,7 +18275,7 @@
     },
     {
         "name": "MonsterNameDusclops",
-        "category": "MonsterCategoryDusclops",
+        "category": "MonsterCategoryBeckon",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18325,7 +18325,7 @@
     },
     {
         "name": "MonsterNameTropius",
-        "category": "MonsterCategoryTropius",
+        "category": "MonsterCategoryFruit",
         "overworldPalette": 8,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18369,7 +18369,7 @@
     },
     {
         "name": "MonsterNameChimecho",
-        "category": "MonsterCategoryChimecho",
+        "category": "MonsterCategoryWindChime",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18413,7 +18413,7 @@
     },
     {
         "name": "MonsterNameAbsol",
-        "category": "MonsterCategoryAbsol",
+        "category": "MonsterCategoryDisaster",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18458,7 +18458,7 @@
     },
     {
         "name": "MonsterNameWynaut",
-        "category": "MonsterCategoryWynaut",
+        "category": "MonsterCategoryBright",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18502,7 +18502,7 @@
     },
     {
         "name": "MonsterNameSnorunt",
-        "category": "MonsterCategorySnorunt",
+        "category": "MonsterCategorySnowHat",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18545,7 +18545,7 @@
     },
     {
         "name": "MonsterNameGlalie",
-        "category": "MonsterCategoryGlalie",
+        "category": "MonsterCategoryFace",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18595,7 +18595,7 @@
     },
     {
         "name": "MonsterNameSpheal",
-        "category": "MonsterCategorySpheal",
+        "category": "MonsterCategoryClap",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18640,7 +18640,7 @@
     },
     {
         "name": "MonsterNameSealeo",
-        "category": "MonsterCategorySealeo",
+        "category": "MonsterCategoryBallRoll",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18692,7 +18692,7 @@
     },
     {
         "name": "MonsterNameWalrein",
-        "category": "MonsterCategoryWalrein",
+        "category": "MonsterCategoryIceBreak",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18744,7 +18744,7 @@
     },
     {
         "name": "MonsterNameClamperl",
-        "category": "MonsterCategoryShellder",
+        "category": "MonsterCategoryBivalve",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18788,7 +18788,7 @@
     },
     {
         "name": "MonsterNameHuntail",
-        "category": "MonsterCategoryHuntail",
+        "category": "MonsterCategoryDeepSea",
         "overworldPalette": 1,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18840,7 +18840,7 @@
     },
     {
         "name": "MonsterNameGorebyss",
-        "category": "MonsterCategoryGorebyss",
+        "category": "MonsterCategorySouthSea",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18892,7 +18892,7 @@
     },
     {
         "name": "MonsterNameRelicanth",
-        "category": "MonsterCategoryRelicanth",
+        "category": "MonsterCategoryLongevity",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18938,7 +18938,7 @@
     },
     {
         "name": "MonsterNameLuvdisc",
-        "category": "MonsterCategoryLuvdisc",
+        "category": "MonsterCategoryRendezvous",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -18982,7 +18982,7 @@
     },
     {
         "name": "MonsterNameBagon",
-        "category": "MonsterCategoryBagon",
+        "category": "MonsterCategoryRockHead",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19025,7 +19025,7 @@
     },
     {
         "name": "MonsterNameShelgon",
-        "category": "MonsterCategoryShelgon",
+        "category": "MonsterCategoryEndurance",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19075,7 +19075,7 @@
     },
     {
         "name": "MonsterNameSalamence",
-        "category": "MonsterCategoryHorsea",
+        "category": "MonsterCategoryDragon",
         "overworldPalette": 5,
         "bodySize": 2,
         "movementSpeed": 1,
@@ -19126,7 +19126,7 @@
     },
     {
         "name": "MonsterNameBeldum",
-        "category": "MonsterCategoryBeldum",
+        "category": "MonsterCategoryIronBall",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19171,7 +19171,7 @@
     },
     {
         "name": "MonsterNameMetang",
-        "category": "MonsterCategoryMetang",
+        "category": "MonsterCategoryIronClaw",
         "overworldPalette": 11,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19223,7 +19223,7 @@
     },
     {
         "name": "MonsterNameMetagross",
-        "category": "MonsterCategoryMetagross",
+        "category": "MonsterCategoryIronLeg",
         "overworldPalette": 11,
         "bodySize": 2,
         "movementSpeed": 1,
@@ -19274,7 +19274,7 @@
     },
     {
         "name": "MonsterNameRegirock",
-        "category": "MonsterCategoryRegirock",
+        "category": "MonsterCategoryRockPeak",
         "overworldPalette": 6,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19317,7 +19317,7 @@
     },
     {
         "name": "MonsterNameRegice",
-        "category": "MonsterCategoryRegice",
+        "category": "MonsterCategoryIceberg",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19360,7 +19360,7 @@
     },
     {
         "name": "MonsterNameRegisteel",
-        "category": "MonsterCategoryRegisteel",
+        "category": "MonsterCategoryIron",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19403,7 +19403,7 @@
     },
     {
         "name": "MonsterNameLatias",
-        "category": "MonsterCategoryLatias",
+        "category": "MonsterCategoryEon",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19450,7 +19450,7 @@
     },
     {
         "name": "MonsterNameLatios",
-        "category": "MonsterCategoryLatias",
+        "category": "MonsterCategoryEon",
         "overworldPalette": 5,
         "bodySize": 2,
         "movementSpeed": 1,
@@ -19497,7 +19497,7 @@
     },
     {
         "name": "MonsterNameKyogre",
-        "category": "MonsterCategoryKyogre",
+        "category": "MonsterCategorySeaBasin",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -19543,7 +19543,7 @@
     },
     {
         "name": "MonsterNameGroudon",
-        "category": "MonsterCategoryGroudon",
+        "category": "MonsterCategoryContinent",
         "overworldPalette": 5,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -19589,7 +19589,7 @@
     },
     {
         "name": "MonsterNameRayquaza",
-        "category": "MonsterCategoryRayquaza",
+        "category": "MonsterCategorySkyHigh",
         "overworldPalette": 3,
         "bodySize": 4,
         "movementSpeed": 1,
@@ -19636,7 +19636,7 @@
     },
     {
         "name": "MonsterNameJirachi",
-        "category": "MonsterCategoryJirachi",
+        "category": "MonsterCategoryWish",
         "overworldPalette": 10,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19682,7 +19682,7 @@
     },
     {
         "name": "MonsterNameDeoxys",
-        "category": "MonsterCategoryDeoxys",
+        "category": "MonsterCategoryDNA",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19728,7 +19728,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19772,7 +19772,7 @@
     },
     {
         "name": "MonsterNameUnown",
-        "category": "MonsterCategoryUnown",
+        "category": "MonsterCategorySymbol",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19816,7 +19816,7 @@
     },
     {
         "name": "MonsterNameDeoxys",
-        "category": "MonsterCategoryDeoxys",
+        "category": "MonsterCategoryDNA",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19861,7 +19861,7 @@
     },
     {
         "name": "MonsterNameDeoxys",
-        "category": "MonsterCategoryDeoxys",
+        "category": "MonsterCategoryDNA",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19906,7 +19906,7 @@
     },
     {
         "name": "MonsterNameDeoxys",
-        "category": "MonsterCategoryDeoxys",
+        "category": "MonsterCategoryDNA",
         "overworldPalette": 9,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19951,7 +19951,7 @@
     },
     {
         "name": "MonsterNameMunchlax",
-        "category": "MonsterCategoryLoudred",
+        "category": "MonsterCategoryBigVoice",
         "overworldPalette": 12,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -19995,7 +19995,7 @@
     },
     {
         "name": "MonsterNameDecoy",
-        "category": "MonsterCategorySlakoth",
+        "category": "MonsterCategorySlacker",
         "overworldPalette": 3,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -20038,7 +20038,7 @@
     },
     {
         "name": "MonsterNameStatue",
-        "category": "MonsterCategoryTorkoal",
+        "category": "MonsterCategoryCoal",
         "overworldPalette": 5,
         "bodySize": 1,
         "movementSpeed": 1,
@@ -20081,7 +20081,7 @@
     },
     {
         "name": "MonsterNameRayquaza",
-        "category": "MonsterCategoryRayquaza",
+        "category": "MonsterCategorySkyHigh",
         "overworldPalette": 3,
         "bodySize": 4,
         "movementSpeed": 1,

--- a/data/monster/monster_names.s
+++ b/data/monster/monster_names.s
@@ -13,8 +13,8 @@ MonsterNameMunchlax:
 .string "Munchlax\0"
 .align 2,0
 
-.global MonsterCategoryDeoxys
-MonsterCategoryDeoxys:
+.global MonsterCategoryDNA
+MonsterCategoryDNA:
 .string "DNA\0"
 .align 2,0
 
@@ -23,8 +23,8 @@ MonsterNameDeoxys:
 .string "Deoxys\0"
 .align 2,0
 
-.global MonsterCategoryJirachi
-MonsterCategoryJirachi:
+.global MonsterCategoryWish
+MonsterCategoryWish:
 .string "Wish\0"
 .align 2,0
 
@@ -33,8 +33,8 @@ MonsterNameJirachi:
 .string "Jirachi\0"
 .align 2,0
 
-.global MonsterCategoryRayquaza
-MonsterCategoryRayquaza:
+.global MonsterCategorySkyHigh
+MonsterCategorySkyHigh:
 .string "Sky High\0"
 .align 2,0
 
@@ -43,8 +43,8 @@ MonsterNameRayquaza:
 .string "Rayquaza\0"
 .align 2,0
 
-.global MonsterCategoryGroudon
-MonsterCategoryGroudon:
+.global MonsterCategoryContinent
+MonsterCategoryContinent:
 .string "Continent\0"
 .align 2,0
 
@@ -53,8 +53,8 @@ MonsterNameGroudon:
 .string "Groudon\0"
 .align 2,0
 
-.global MonsterCategoryKyogre
-MonsterCategoryKyogre:
+.global MonsterCategorySeaBasin
+MonsterCategorySeaBasin:
 .string "Sea Basin\0"
 .align 2,0
 
@@ -68,8 +68,8 @@ MonsterNameLatios:
 .string "Latios\0"
 .align 2,0
 
-.global MonsterCategoryLatias
-MonsterCategoryLatias:
+.global MonsterCategoryEon
+MonsterCategoryEon:
 .string "Eon\0"
 .align 2,0
 
@@ -78,8 +78,8 @@ MonsterNameLatias:
 .string "Latias\0"
 .align 2,0
 
-.global MonsterCategoryRegisteel
-MonsterCategoryRegisteel:
+.global MonsterCategoryIron
+MonsterCategoryIron:
 .string "Iron\0"
 .align 2,0
 
@@ -88,8 +88,8 @@ MonsterNameRegisteel:
 .string "Registeel\0"
 .align 2,0
 
-.global MonsterCategoryRegice
-MonsterCategoryRegice:
+.global MonsterCategoryIceberg
+MonsterCategoryIceberg:
 .string "Iceberg\0"
 .align 2,0
 
@@ -98,8 +98,8 @@ MonsterNameRegice:
 .string "Regice\0"
 .align 2,0
 
-.global MonsterCategoryRegirock
-MonsterCategoryRegirock:
+.global MonsterCategoryRockPeak
+MonsterCategoryRockPeak:
 .string "Rock Peak\0"
 .align 2,0
 
@@ -108,8 +108,8 @@ MonsterNameRegirock:
 .string "Regirock\0"
 .align 2,0
 
-.global MonsterCategoryMetagross
-MonsterCategoryMetagross:
+.global MonsterCategoryIronLeg
+MonsterCategoryIronLeg:
 .string "Iron Leg\0"
 .align 2,0
 
@@ -118,8 +118,8 @@ MonsterNameMetagross:
 .string "Metagross\0"
 .align 2,0
 
-.global MonsterCategoryMetang
-MonsterCategoryMetang:
+.global MonsterCategoryIronClaw
+MonsterCategoryIronClaw:
 .string "Iron Claw\0"
 .align 2,0
 
@@ -128,8 +128,8 @@ MonsterNameMetang:
 .string "Metang\0"
 .align 2,0
 
-.global MonsterCategoryBeldum
-MonsterCategoryBeldum:
+.global MonsterCategoryIronBall
+MonsterCategoryIronBall:
 .string "Iron Ball\0"
 .align 2,0
 
@@ -143,8 +143,8 @@ MonsterNameSalamence:
 .string "Salamence\0"
 .align 2,0
 
-.global MonsterCategoryShelgon
-MonsterCategoryShelgon:
+.global MonsterCategoryEndurance
+MonsterCategoryEndurance:
 .string "Endurance\0"
 .align 2,0
 
@@ -153,8 +153,8 @@ MonsterNameShelgon:
 .string "Shelgon\0"
 .align 2,0
 
-.global MonsterCategoryBagon
-MonsterCategoryBagon:
+.global MonsterCategoryRockHead
+MonsterCategoryRockHead:
 .string "Rock Head\0"
 .align 2,0
 
@@ -163,8 +163,8 @@ MonsterNameBagon:
 .string "Bagon\0"
 .align 2,0
 
-.global MonsterCategoryLuvdisc
-MonsterCategoryLuvdisc:
+.global MonsterCategoryRendezvous
+MonsterCategoryRendezvous:
 .string "Rendezvous\0"
 .align 2,0
 
@@ -173,8 +173,8 @@ MonsterNameLuvdisc:
 .string "Luvdisc\0"
 .align 2,0
 
-.global MonsterCategoryRelicanth
-MonsterCategoryRelicanth:
+.global MonsterCategoryLongevity
+MonsterCategoryLongevity:
 .string "Longevity\0"
 .align 2,0
 
@@ -183,8 +183,8 @@ MonsterNameRelicanth:
 .string "Relicanth\0"
 .align 2,0
 
-.global MonsterCategoryGorebyss
-MonsterCategoryGorebyss:
+.global MonsterCategorySouthSea
+MonsterCategorySouthSea:
 .string "South Sea\0"
 .align 2,0
 
@@ -193,8 +193,8 @@ MonsterNameGorebyss:
 .string "Gorebyss\0"
 .align 2,0
 
-.global MonsterCategoryHuntail
-MonsterCategoryHuntail:
+.global MonsterCategoryDeepSea
+MonsterCategoryDeepSea:
 .string "Deep Sea\0"
 .align 2,0
 
@@ -208,8 +208,8 @@ MonsterNameClamperl:
 .string "Clamperl\0"
 .align 2,0
 
-.global MonsterCategoryWalrein
-MonsterCategoryWalrein:
+.global MonsterCategoryIceBreak
+MonsterCategoryIceBreak:
 .string "Ice Break\0"
 .align 2,0
 
@@ -218,8 +218,8 @@ MonsterNameWalrein:
 .string "Walrein\0"
 .align 2,0
 
-.global MonsterCategorySealeo
-MonsterCategorySealeo:
+.global MonsterCategoryBallRoll
+MonsterCategoryBallRoll:
 .string "Ball Roll\0"
 .align 2,0
 
@@ -228,8 +228,8 @@ MonsterNameSealeo:
 .string "Sealeo\0"
 .align 2,0
 
-.global MonsterCategorySpheal
-MonsterCategorySpheal:
+.global MonsterCategoryClap
+MonsterCategoryClap:
 .string "Clap\0"
 .align 2,0
 
@@ -238,8 +238,8 @@ MonsterNameSpheal:
 .string "Spheal\0"
 .align 2,0
 
-.global MonsterCategoryGlalie
-MonsterCategoryGlalie:
+.global MonsterCategoryFace
+MonsterCategoryFace:
 .string "Face\0"
 .align 2,0
 
@@ -248,8 +248,8 @@ MonsterNameGlalie:
 .string "Glalie\0"
 .align 2,0
 
-.global MonsterCategorySnorunt
-MonsterCategorySnorunt:
+.global MonsterCategorySnowHat
+MonsterCategorySnowHat:
 .string "Snow Hat\0"
 .align 2,0
 
@@ -258,8 +258,8 @@ MonsterNameSnorunt:
 .string "Snorunt\0"
 .align 2,0
 
-.global MonsterCategoryWynaut
-MonsterCategoryWynaut:
+.global MonsterCategoryBright
+MonsterCategoryBright:
 .string "Bright\0"
 .align 2,0
 
@@ -268,8 +268,8 @@ MonsterNameWynaut:
 .string "Wynaut\0"
 .align 2,0
 
-.global MonsterCategoryAbsol
-MonsterCategoryAbsol:
+.global MonsterCategoryDisaster
+MonsterCategoryDisaster:
 .string "Disaster\0"
 .align 2,0
 
@@ -278,8 +278,8 @@ MonsterNameAbsol:
 .string "Absol\0"
 .align 2,0
 
-.global MonsterCategoryChimecho
-MonsterCategoryChimecho:
+.global MonsterCategoryWindChime
+MonsterCategoryWindChime:
 .string "Wind Chime\0"
 .align 2,0
 
@@ -288,8 +288,8 @@ MonsterNameChimecho:
 .string "Chimecho\0"
 .align 2,0
 
-.global MonsterCategoryTropius
-MonsterCategoryTropius:
+.global MonsterCategoryFruit
+MonsterCategoryFruit:
 .string "Fruit\0"
 .align 2,0
 
@@ -298,8 +298,8 @@ MonsterNameTropius:
 .string "Tropius\0"
 .align 2,0
 
-.global MonsterCategoryDusclops
-MonsterCategoryDusclops:
+.global MonsterCategoryBeckon
+MonsterCategoryBeckon:
 .string "Beckon\0"
 .align 2,0
 
@@ -308,8 +308,8 @@ MonsterNameDusclops:
 .string "Dusclops\0"
 .align 2,0
 
-.global MonsterCategoryDuskull
-MonsterCategoryDuskull:
+.global MonsterCategoryRequiem
+MonsterCategoryRequiem:
 .string "Requiem\0"
 .align 2,0
 
@@ -318,8 +318,8 @@ MonsterNameDuskull:
 .string "Duskull\0"
 .align 2,0
 
-.global MonsterCategoryBanette
-MonsterCategoryBanette:
+.global MonsterCategoryMarionette
+MonsterCategoryMarionette:
 .string "Marionette\0"
 .align 2,0
 
@@ -328,8 +328,8 @@ MonsterNameBanette:
 .string "Banette\0"
 .align 2,0
 
-.global MonsterCategoryShuppet
-MonsterCategoryShuppet:
+.global MonsterCategoryPuppet
+MonsterCategoryPuppet:
 .string "Puppet\0"
 .align 2,0
 
@@ -338,8 +338,8 @@ MonsterNameShuppet:
 .string "Shuppet\0"
 .align 2,0
 
-.global MonsterCategoryKecleon
-MonsterCategoryKecleon:
+.global MonsterCategoryColorSwap
+MonsterCategoryColorSwap:
 .string "Color Swap\0"
 .align 2,0
 
@@ -348,8 +348,8 @@ MonsterNameKecleon:
 .string "Kecleon\0"
 .align 2,0
 
-.global MonsterCategoryCastform
-MonsterCategoryCastform:
+.global MonsterCategoryWeather
+MonsterCategoryWeather:
 .string "Weather\0"
 .align 2,0
 
@@ -358,8 +358,8 @@ MonsterNameCastform:
 .string "Castform\0"
 .align 2,0
 
-.global MonsterCategoryMilotic
-MonsterCategoryMilotic:
+.global MonsterCategoryTender
+MonsterCategoryTender:
 .string "Tender\0"
 .align 2,0
 
@@ -373,8 +373,8 @@ MonsterNameFeebas:
 .string "Feebas\0"
 .align 2,0
 
-.global MonsterCategoryArmaldo
-MonsterCategoryArmaldo:
+.global MonsterCategoryPlate
+MonsterCategoryPlate:
 .string "Plate\0"
 .align 2,0
 
@@ -383,8 +383,8 @@ MonsterNameArmaldo:
 .string "Armaldo\0"
 .align 2,0
 
-.global MonsterCategoryAnorith
-MonsterCategoryAnorith:
+.global MonsterCategoryOldShrimp
+MonsterCategoryOldShrimp:
 .string "Old Shrimp\0"
 .align 2,0
 
@@ -393,8 +393,8 @@ MonsterNameAnorith:
 .string "Anorith\0"
 .align 2,0
 
-.global MonsterCategoryCradily
-MonsterCategoryCradily:
+.global MonsterCategoryBarnacle
+MonsterCategoryBarnacle:
 .string "Barnacle\0"
 .align 2,0
 
@@ -403,8 +403,8 @@ MonsterNameCradily:
 .string "Cradily\0"
 .align 2,0
 
-.global MonsterCategoryLileep
-MonsterCategoryLileep:
+.global MonsterCategorySeaLily
+MonsterCategorySeaLily:
 .string "Sea Lily\0"
 .align 2,0
 
@@ -418,8 +418,8 @@ MonsterNameClaydol:
 .string "Claydol\0"
 .align 2,0
 
-.global MonsterCategoryBaltoy
-MonsterCategoryBaltoy:
+.global MonsterCategoryClayDoll
+MonsterCategoryClayDoll:
 .string "Clay Doll\0"
 .align 2,0
 
@@ -428,8 +428,8 @@ MonsterNameBaltoy:
 .string "Baltoy\0"
 .align 2,0
 
-.global MonsterCategoryCrawdaunt
-MonsterCategoryCrawdaunt:
+.global MonsterCategoryRogue
+MonsterCategoryRogue:
 .string "Rogue\0"
 .align 2,0
 
@@ -438,8 +438,8 @@ MonsterNameCrawdaunt:
 .string "Crawdaunt\0"
 .align 2,0
 
-.global MonsterCategoryCorphish
-MonsterCategoryCorphish:
+.global MonsterCategoryRuffian
+MonsterCategoryRuffian:
 .string "Ruffian\0"
 .align 2,0
 
@@ -453,8 +453,8 @@ MonsterNameWhiscash:
 .string "Whiscash\0"
 .align 2,0
 
-.global MonsterCategoryBarboach
-MonsterCategoryBarboach:
+.global MonsterCategoryWhiskers
+MonsterCategoryWhiskers:
 .string "Whiskers\0"
 .align 2,0
 
@@ -468,8 +468,8 @@ MonsterNameSolrock:
 .string "Solrock\0"
 .align 2,0
 
-.global MonsterCategoryLunatone
-MonsterCategoryLunatone:
+.global MonsterCategoryMeteorite
+MonsterCategoryMeteorite:
 .string "Meteorite\0"
 .align 2,0
 
@@ -478,8 +478,8 @@ MonsterNameLunatone:
 .string "Lunatone\0"
 .align 2,0
 
-.global MonsterCategorySeviper
-MonsterCategorySeviper:
+.global MonsterCategoryFangSnake
+MonsterCategoryFangSnake:
 .string "Fang Snake\0"
 .align 2,0
 
@@ -488,8 +488,8 @@ MonsterNameSeviper:
 .string "Seviper\0"
 .align 2,0
 
-.global MonsterCategoryZangoose
-MonsterCategoryZangoose:
+.global MonsterCategoryCatFerret
+MonsterCategoryCatFerret:
 .string "Cat Ferret\0"
 .align 2,0
 
@@ -498,8 +498,8 @@ MonsterNameZangoose:
 .string "Zangoose\0"
 .align 2,0
 
-.global MonsterCategoryAltaria
-MonsterCategoryAltaria:
+.global MonsterCategoryHumming
+MonsterCategoryHumming:
 .string "Humming\0"
 .align 2,0
 
@@ -508,8 +508,8 @@ MonsterNameAltaria:
 .string "Altaria\0"
 .align 2,0
 
-.global MonsterCategorySwablu
-MonsterCategorySwablu:
+.global MonsterCategoryCottonBird
+MonsterCategoryCottonBird:
 .string "Cotton Bird\0"
 .align 2,0
 
@@ -518,8 +518,8 @@ MonsterNameSwablu:
 .string "Swablu\0"
 .align 2,0
 
-.global MonsterCategoryCacturne
-MonsterCategoryCacturne:
+.global MonsterCategoryScarecrow
+MonsterCategoryScarecrow:
 .string "Scarecrow\0"
 .align 2,0
 
@@ -528,8 +528,8 @@ MonsterNameCacturne:
 .string "Cacturne\0"
 .align 2,0
 
-.global MonsterCategoryCacnea
-MonsterCategoryCacnea:
+.global MonsterCategoryCactus
+MonsterCategoryCactus:
 .string "Cactus\0"
 .align 2,0
 
@@ -543,8 +543,8 @@ MonsterNameFlygon:
 .string "Flygon\0"
 .align 2,0
 
-.global MonsterCategoryVibrava
-MonsterCategoryVibrava:
+.global MonsterCategoryVibration
+MonsterCategoryVibration:
 .string "Vibration\0"
 .align 2,0
 
@@ -553,8 +553,8 @@ MonsterNameVibrava:
 .string "Vibrava\0"
 .align 2,0
 
-.global MonsterCategoryTrapinch
-MonsterCategoryTrapinch:
+.global MonsterCategoryAntPit
+MonsterCategoryAntPit:
 .string "Ant Pit\0"
 .align 2,0
 
@@ -563,8 +563,8 @@ MonsterNameTrapinch:
 .string "Trapinch\0"
 .align 2,0
 
-.global MonsterCategorySpinda
-MonsterCategorySpinda:
+.global MonsterCategorySpotPanda
+MonsterCategorySpotPanda:
 .string "Spot Panda\0"
 .align 2,0
 
@@ -573,8 +573,8 @@ MonsterNameSpinda:
 .string "Spinda\0"
 .align 2,0
 
-.global MonsterCategoryGrumpig
-MonsterCategoryGrumpig:
+.global MonsterCategoryManipulate
+MonsterCategoryManipulate:
 .string "Manipulate\0"
 .align 2,0
 
@@ -583,8 +583,8 @@ MonsterNameGrumpig:
 .string "Grumpig\0"
 .align 2,0
 
-.global MonsterCategorySpoink
-MonsterCategorySpoink:
+.global MonsterCategoryBounce
+MonsterCategoryBounce:
 .string "Bounce\0"
 .align 2,0
 
@@ -593,8 +593,8 @@ MonsterNameSpoink:
 .string "Spoink\0"
 .align 2,0
 
-.global MonsterCategoryTorkoal
-MonsterCategoryTorkoal:
+.global MonsterCategoryCoal
+MonsterCategoryCoal:
 .string "Coal\0"
 .align 2,0
 
@@ -608,8 +608,8 @@ MonsterNameCamerupt:
 .string "Camerupt\0"
 .align 2,0
 
-.global MonsterCategoryNumel
-MonsterCategoryNumel:
+.global MonsterCategoryNumb
+MonsterCategoryNumb:
 .string "Numb\0"
 .align 2,0
 
@@ -618,8 +618,8 @@ MonsterNameNumel:
 .string "Numel\0"
 .align 2,0
 
-.global MonsterCategoryWailord
-MonsterCategoryWailord:
+.global MonsterCategoryFloatWhale
+MonsterCategoryFloatWhale:
 .string "Float Whale\0"
 .align 2,0
 
@@ -628,8 +628,8 @@ MonsterNameWailord:
 .string "Wailord\0"
 .align 2,0
 
-.global MonsterCategoryWailmer
-MonsterCategoryWailmer:
+.global MonsterCategoryBallWhale
+MonsterCategoryBallWhale:
 .string "Ball Whale\0"
 .align 2,0
 
@@ -638,8 +638,8 @@ MonsterNameWailmer:
 .string "Wailmer\0"
 .align 2,0
 
-.global MonsterCategorySharpedo
-MonsterCategorySharpedo:
+.global MonsterCategoryBrutal
+MonsterCategoryBrutal:
 .string "Brutal\0"
 .align 2,0
 
@@ -648,8 +648,8 @@ MonsterNameSharpedo:
 .string "Sharpedo\0"
 .align 2,0
 
-.global MonsterCategoryCarvanha
-MonsterCategoryCarvanha:
+.global MonsterCategorySavage
+MonsterCategorySavage:
 .string "Savage\0"
 .align 2,0
 
@@ -658,8 +658,8 @@ MonsterNameCarvanha:
 .string "Carvanha\0"
 .align 2,0
 
-.global MonsterCategorySwalot
-MonsterCategorySwalot:
+.global MonsterCategoryPoisonBag
+MonsterCategoryPoisonBag:
 .string "Poison Bag\0"
 .align 2,0
 
@@ -668,8 +668,8 @@ MonsterNameSwalot:
 .string "Swalot\0"
 .align 2,0
 
-.global MonsterCategoryGulpin
-MonsterCategoryGulpin:
+.global MonsterCategoryStomach
+MonsterCategoryStomach:
 .string "Stomach\0"
 .align 2,0
 
@@ -678,8 +678,8 @@ MonsterNameGulpin:
 .string "Gulpin\0"
 .align 2,0
 
-.global MonsterCategoryRoselia
-MonsterCategoryRoselia:
+.global MonsterCategoryThorn
+MonsterCategoryThorn:
 .string "Thorn\0"
 .align 2,0
 
@@ -693,8 +693,8 @@ MonsterNameIllumise:
 .string "Illumise\0"
 .align 2,0
 
-.global MonsterCategoryVolbeat
-MonsterCategoryVolbeat:
+.global MonsterCategoryFirefly
+MonsterCategoryFirefly:
 .string "Firefly\0"
 .align 2,0
 
@@ -708,8 +708,8 @@ MonsterNameMinun:
 .string "Minun\0"
 .align 2,0
 
-.global MonsterCategoryPlusle
-MonsterCategoryPlusle:
+.global MonsterCategoryCheering
+MonsterCategoryCheering:
 .string "Cheering\0"
 .align 2,0
 
@@ -718,8 +718,8 @@ MonsterNamePlusle:
 .string "Plusle\0"
 .align 2,0
 
-.global MonsterCategoryManectric
-MonsterCategoryManectric:
+.global MonsterCategoryDischarge
+MonsterCategoryDischarge:
 .string "Discharge\0"
 .align 2,0
 
@@ -738,8 +738,8 @@ MonsterNameMedicham:
 .string "Medicham\0"
 .align 2,0
 
-.global MonsterCategoryMeditite
-MonsterCategoryMeditite:
+.global MonsterCategoryMeditate
+MonsterCategoryMeditate:
 .string "Meditate\0"
 .align 2,0
 
@@ -758,8 +758,8 @@ MonsterNameLairon:
 .string "Lairon\0"
 .align 2,0
 
-.global MonsterCategoryAron
-MonsterCategoryAron:
+.global MonsterCategoryIronArmor
+MonsterCategoryIronArmor:
 .string "Iron Armor\0"
 .align 2,0
 
@@ -768,8 +768,8 @@ MonsterNameAron:
 .string "Aron\0"
 .align 2,0
 
-.global MonsterCategoryMawile
-MonsterCategoryMawile:
+.global MonsterCategoryDeceiver
+MonsterCategoryDeceiver:
 .string "Deceiver\0"
 .align 2,0
 
@@ -783,8 +783,8 @@ MonsterNameSableye:
 .string "Sableye\0"
 .align 2,0
 
-.global MonsterCategoryDelcatty
-MonsterCategoryDelcatty:
+.global MonsterCategoryPrim
+MonsterCategoryPrim:
 .string "Prim\0"
 .align 2,0
 
@@ -793,8 +793,8 @@ MonsterNameDelcatty:
 .string "Delcatty\0"
 .align 2,0
 
-.global MonsterCategorySkitty
-MonsterCategorySkitty:
+.global MonsterCategoryKitten
+MonsterCategoryKitten:
 .string "Kitten\0"
 .align 2,0
 
@@ -803,8 +803,8 @@ MonsterNameSkitty:
 .string "Skitty\0"
 .align 2,0
 
-.global MonsterCategoryNosepass
-MonsterCategoryNosepass:
+.global MonsterCategoryCompass
+MonsterCategoryCompass:
 .string "Compass\0"
 .align 2,0
 
@@ -813,8 +813,8 @@ MonsterNameNosepass:
 .string "Nosepass\0"
 .align 2,0
 
-.global MonsterCategoryAzurill
-MonsterCategoryAzurill:
+.global MonsterCategoryPolkaDot
+MonsterCategoryPolkaDot:
 .string "Polka Dot\0"
 .align 2,0
 
@@ -823,8 +823,8 @@ MonsterNameAzurill:
 .string "Azurill\0"
 .align 2,0
 
-.global MonsterCategoryHariyama
-MonsterCategoryHariyama:
+.global MonsterCategoryArmThrust
+MonsterCategoryArmThrust:
 .string "Arm Thrust\0"
 .align 2,0
 
@@ -833,8 +833,8 @@ MonsterNameHariyama:
 .string "Hariyama\0"
 .align 2,0
 
-.global MonsterCategoryMakuhita
-MonsterCategoryMakuhita:
+.global MonsterCategoryGuts
+MonsterCategoryGuts:
 .string "Guts\0"
 .align 2,0
 
@@ -843,8 +843,8 @@ MonsterNameMakuhita:
 .string "Makuhita\0"
 .align 2,0
 
-.global MonsterCategoryExploud
-MonsterCategoryExploud:
+.global MonsterCategoryLoudNoise
+MonsterCategoryLoudNoise:
 .string "Loud Noise\0"
 .align 2,0
 
@@ -853,8 +853,8 @@ MonsterNameExploud:
 .string "Exploud\0"
 .align 2,0
 
-.global MonsterCategoryLoudred
-MonsterCategoryLoudred:
+.global MonsterCategoryBigVoice
+MonsterCategoryBigVoice:
 .string "Big Voice\0"
 .align 2,0
 
@@ -863,8 +863,8 @@ MonsterNameLoudred:
 .string "Loudred\0"
 .align 2,0
 
-.global MonsterCategoryWhismur
-MonsterCategoryWhismur:
+.global MonsterCategoryWhisper
+MonsterCategoryWhisper:
 .string "Whisper\0"
 .align 2,0
 
@@ -873,8 +873,8 @@ MonsterNameWhismur:
 .string "Whismur\0"
 .align 2,0
 
-.global MonsterCategoryShedinja
-MonsterCategoryShedinja:
+.global MonsterCategoryShed
+MonsterCategoryShed:
 .string "Shed\0"
 .align 2,0
 
@@ -883,8 +883,8 @@ MonsterNameShedinja:
 .string "Shedinja\0"
 .align 2,0
 
-.global MonsterCategoryNinjask
-MonsterCategoryNinjask:
+.global MonsterCategoryNinja
+MonsterCategoryNinja:
 .string "Ninja\0"
 .align 2,0
 
@@ -893,8 +893,8 @@ MonsterNameNinjask:
 .string "Ninjask\0"
 .align 2,0
 
-.global MonsterCategoryNincada
-MonsterCategoryNincada:
+.global MonsterCategoryTrainee
+MonsterCategoryTrainee:
 .string "Trainee\0"
 .align 2,0
 
@@ -903,8 +903,8 @@ MonsterNameNincada:
 .string "Nincada\0"
 .align 2,0
 
-.global MonsterCategorySlaking
-MonsterCategorySlaking:
+.global MonsterCategoryLazy
+MonsterCategoryLazy:
 .string "Lazy\0"
 .align 2,0
 
@@ -913,8 +913,8 @@ MonsterNameSlaking:
 .string "Slaking\0"
 .align 2,0
 
-.global MonsterCategoryVigoroth
-MonsterCategoryVigoroth:
+.global MonsterCategoryWildMonkey
+MonsterCategoryWildMonkey:
 .string "Wild Monkey\0"
 .align 2,0
 
@@ -923,8 +923,8 @@ MonsterNameVigoroth:
 .string "Vigoroth\0"
 .align 2,0
 
-.global MonsterCategorySlakoth
-MonsterCategorySlakoth:
+.global MonsterCategorySlacker
+MonsterCategorySlacker:
 .string "Slacker\0"
 .align 2,0
 
@@ -943,8 +943,8 @@ MonsterNameShroomish:
 .string "Shroomish\0"
 .align 2,0
 
-.global MonsterCategoryMasquerain
-MonsterCategoryMasquerain:
+.global MonsterCategoryEyeball
+MonsterCategoryEyeball:
 .string "Eyeball\0"
 .align 2,0
 
@@ -953,8 +953,8 @@ MonsterNameMasquerain:
 .string "Masquerain\0"
 .align 2,0
 
-.global MonsterCategorySurskit
-MonsterCategorySurskit:
+.global MonsterCategoryPondSkater
+MonsterCategoryPondSkater:
 .string "Pond Skater\0"
 .align 2,0
 
@@ -963,8 +963,8 @@ MonsterNameSurskit:
 .string "Surskit\0"
 .align 2,0
 
-.global MonsterCategoryGardevoir
-MonsterCategoryGardevoir:
+.global MonsterCategoryEmbrace
+MonsterCategoryEmbrace:
 .string "Embrace\0"
 .align 2,0
 
@@ -973,8 +973,8 @@ MonsterNameGardevoir:
 .string "Gardevoir\0"
 .align 2,0
 
-.global MonsterCategoryKirlia
-MonsterCategoryKirlia:
+.global MonsterCategoryEmotion
+MonsterCategoryEmotion:
 .string "Emotion\0"
 .align 2,0
 
@@ -983,8 +983,8 @@ MonsterNameKirlia:
 .string "Kirlia\0"
 .align 2,0
 
-.global MonsterCategoryRalts
-MonsterCategoryRalts:
+.global MonsterCategoryFeeling
+MonsterCategoryFeeling:
 .string "Feeling\0"
 .align 2,0
 
@@ -993,8 +993,8 @@ MonsterNameRalts:
 .string "Ralts\0"
 .align 2,0
 
-.global MonsterCategoryPelipper
-MonsterCategoryPelipper:
+.global MonsterCategoryWaterBird
+MonsterCategoryWaterBird:
 .string "Water Bird\0"
 .align 2,0
 
@@ -1003,8 +1003,8 @@ MonsterNamePelipper:
 .string "Pelipper\0"
 .align 2,0
 
-.global MonsterCategoryWingull
-MonsterCategoryWingull:
+.global MonsterCategorySeagull
+MonsterCategorySeagull:
 .string "Seagull\0"
 .align 2,0
 
@@ -1013,8 +1013,8 @@ MonsterNameWingull:
 .string "Wingull\0"
 .align 2,0
 
-.global MonsterCategorySwellow
-MonsterCategorySwellow:
+.global MonsterCategorySwallow
+MonsterCategorySwallow:
 .string "Swallow\0"
 .align 2,0
 
@@ -1023,8 +1023,8 @@ MonsterNameSwellow:
 .string "Swellow\0"
 .align 2,0
 
-.global MonsterCategoryTaillow
-MonsterCategoryTaillow:
+.global MonsterCategoryTinyswallow
+MonsterCategoryTinyswallow:
 .string "Tinyswallow\0"
 .align 2,0
 
@@ -1033,8 +1033,8 @@ MonsterNameTaillow:
 .string "Taillow\0"
 .align 2,0
 
-.global MonsterCategoryShiftry
-MonsterCategoryShiftry:
+.global MonsterCategoryWicked
+MonsterCategoryWicked:
 .string "Wicked\0"
 .align 2,0
 
@@ -1043,8 +1043,8 @@ MonsterNameShiftry:
 .string "Shiftry\0"
 .align 2,0
 
-.global MonsterCategoryNuzleaf
-MonsterCategoryNuzleaf:
+.global MonsterCategoryWily
+MonsterCategoryWily:
 .string "Wily\0"
 .align 2,0
 
@@ -1053,8 +1053,8 @@ MonsterNameNuzleaf:
 .string "Nuzleaf\0"
 .align 2,0
 
-.global MonsterCategorySeedot
-MonsterCategorySeedot:
+.global MonsterCategoryAcorn
+MonsterCategoryAcorn:
 .string "Acorn\0"
 .align 2,0
 
@@ -1063,8 +1063,8 @@ MonsterNameSeedot:
 .string "Seedot\0"
 .align 2,0
 
-.global MonsterCategoryLudicolo
-MonsterCategoryLudicolo:
+.global MonsterCategoryCarefree
+MonsterCategoryCarefree:
 .string "Carefree\0"
 .align 2,0
 
@@ -1073,8 +1073,8 @@ MonsterNameLudicolo:
 .string "Ludicolo\0"
 .align 2,0
 
-.global MonsterCategoryLombre
-MonsterCategoryLombre:
+.global MonsterCategoryJolly
+MonsterCategoryJolly:
 .string "Jolly\0"
 .align 2,0
 
@@ -1083,8 +1083,8 @@ MonsterNameLombre:
 .string "Lombre\0"
 .align 2,0
 
-.global MonsterCategoryLotad
-MonsterCategoryLotad:
+.global MonsterCategoryWaterWeed
+MonsterCategoryWaterWeed:
 .string "Water Weed\0"
 .align 2,0
 
@@ -1118,8 +1118,8 @@ MonsterNameWurmple:
 .string "Wurmple\0"
 .align 2,0
 
-.global MonsterCategoryLinoone
-MonsterCategoryLinoone:
+.global MonsterCategoryRushing
+MonsterCategoryRushing:
 .string "Rushing\0"
 .align 2,0
 
@@ -1128,8 +1128,8 @@ MonsterNameLinoone:
 .string "Linoone\0"
 .align 2,0
 
-.global MonsterCategoryZigzagoon
-MonsterCategoryZigzagoon:
+.global MonsterCategoryTinyraccoon
+MonsterCategoryTinyraccoon:
 .string "Tinyraccoon\0"
 .align 2,0
 
@@ -1143,8 +1143,8 @@ MonsterNameMightyena:
 .string "Mightyena\0"
 .align 2,0
 
-.global MonsterCategoryPoochyena
-MonsterCategoryPoochyena:
+.global MonsterCategoryBite
+MonsterCategoryBite:
 .string "Bite\0"
 .align 2,0
 
@@ -1163,8 +1163,8 @@ MonsterNameMarshtomp:
 .string "Marshtomp\0"
 .align 2,0
 
-.global MonsterCategoryMudkip
-MonsterCategoryMudkip:
+.global MonsterCategoryMudFish
+MonsterCategoryMudFish:
 .string "Mud Fish\0"
 .align 2,0
 
@@ -1173,8 +1173,8 @@ MonsterNameMudkip:
 .string "Mudkip\0"
 .align 2,0
 
-.global MonsterCategoryBlaziken
-MonsterCategoryBlaziken:
+.global MonsterCategoryBlaze
+MonsterCategoryBlaze:
 .string "Blaze\0"
 .align 2,0
 
@@ -1183,8 +1183,8 @@ MonsterNameBlaziken:
 .string "Blaziken\0"
 .align 2,0
 
-.global MonsterCategoryCombusken
-MonsterCategoryCombusken:
+.global MonsterCategoryYoungFowl
+MonsterCategoryYoungFowl:
 .string "Young Fowl\0"
 .align 2,0
 
@@ -1193,8 +1193,8 @@ MonsterNameCombusken:
 .string "Combusken\0"
 .align 2,0
 
-.global MonsterCategoryTorchic
-MonsterCategoryTorchic:
+.global MonsterCategoryChick
+MonsterCategoryChick:
 .string "Chick\0"
 .align 2,0
 
@@ -1203,8 +1203,8 @@ MonsterNameTorchic:
 .string "Torchic\0"
 .align 2,0
 
-.global MonsterCategorySceptile
-MonsterCategorySceptile:
+.global MonsterCategoryForest
+MonsterCategoryForest:
 .string "Forest\0"
 .align 2,0
 
@@ -1218,8 +1218,8 @@ MonsterNameGrovyle:
 .string "Grovyle\0"
 .align 2,0
 
-.global MonsterCategoryTreecko
-MonsterCategoryTreecko:
+.global MonsterCategoryWoodGecko
+MonsterCategoryWoodGecko:
 .string "Wood Gecko\0"
 .align 2,0
 
@@ -1228,8 +1228,8 @@ MonsterNameTreecko:
 .string "Treecko\0"
 .align 2,0
 
-.global MonsterCategoryCelebi
-MonsterCategoryCelebi:
+.global MonsterCategoryTimeTravel
+MonsterCategoryTimeTravel:
 .string "Time Travel\0"
 .align 2,0
 
@@ -1238,8 +1238,8 @@ MonsterNameCelebi:
 .string "Celebi\0"
 .align 2,0
 
-.global MonsterCategoryHoOh
-MonsterCategoryHoOh:
+.global MonsterCategoryRainbow
+MonsterCategoryRainbow:
 .string "Rainbow\0"
 .align 2,0
 
@@ -1248,8 +1248,8 @@ MonsterNameHoOh:
 .string "Ho-Oh\0"
 .align 2,0
 
-.global MonsterCategoryLugia
-MonsterCategoryLugia:
+.global MonsterCategoryDiving
+MonsterCategoryDiving:
 .string "Diving\0"
 .align 2,0
 
@@ -1263,8 +1263,8 @@ MonsterNameTyranitar:
 .string "Tyranitar\0"
 .align 2,0
 
-.global MonsterCategoryPupitar
-MonsterCategoryPupitar:
+.global MonsterCategoryHardShell
+MonsterCategoryHardShell:
 .string "Hard Shell\0"
 .align 2,0
 
@@ -1273,8 +1273,8 @@ MonsterNamePupitar:
 .string "Pupitar\0"
 .align 2,0
 
-.global MonsterCategoryLarvitar
-MonsterCategoryLarvitar:
+.global MonsterCategoryRockSkin
+MonsterCategoryRockSkin:
 .string "Rock Skin\0"
 .align 2,0
 
@@ -1283,8 +1283,8 @@ MonsterNameLarvitar:
 .string "Larvitar\0"
 .align 2,0
 
-.global MonsterCategorySuicune
-MonsterCategorySuicune:
+.global MonsterCategoryAurora
+MonsterCategoryAurora:
 .string "Aurora\0"
 .align 2,0
 
@@ -1298,8 +1298,8 @@ MonsterNameEntei:
 .string "Entei\0"
 .align 2,0
 
-.global MonsterCategoryRaikou
-MonsterCategoryRaikou:
+.global MonsterCategoryThunder
+MonsterCategoryThunder:
 .string "Thunder\0"
 .align 2,0
 
@@ -1313,8 +1313,8 @@ MonsterNameBlissey:
 .string "Blissey\0"
 .align 2,0
 
-.global MonsterCategoryMiltank
-MonsterCategoryMiltank:
+.global MonsterCategoryMilkCow
+MonsterCategoryMilkCow:
 .string "Milk Cow\0"
 .align 2,0
 
@@ -1323,8 +1323,8 @@ MonsterNameMiltank:
 .string "Miltank\0"
 .align 2,0
 
-.global MonsterCategoryMagby
-MonsterCategoryMagby:
+.global MonsterCategoryLiveCoal
+MonsterCategoryLiveCoal:
 .string "Live Coal\0"
 .align 2,0
 
@@ -1338,8 +1338,8 @@ MonsterNameElekid:
 .string "Elekid\0"
 .align 2,0
 
-.global MonsterCategorySmoochum
-MonsterCategorySmoochum:
+.global MonsterCategoryKiss
+MonsterCategoryKiss:
 .string "Kiss\0"
 .align 2,0
 
@@ -1348,8 +1348,8 @@ MonsterNameSmoochum:
 .string "Smoochum\0"
 .align 2,0
 
-.global MonsterCategoryHitmontop
-MonsterCategoryHitmontop:
+.global MonsterCategoryHandstand
+MonsterCategoryHandstand:
 .string "Handstand\0"
 .align 2,0
 
@@ -1358,8 +1358,8 @@ MonsterNameHitmontop:
 .string "Hitmontop\0"
 .align 2,0
 
-.global MonsterCategoryTyrogue
-MonsterCategoryTyrogue:
+.global MonsterCategoryScuffle
+MonsterCategoryScuffle:
 .string "Scuffle\0"
 .align 2,0
 
@@ -1368,8 +1368,8 @@ MonsterNameTyrogue:
 .string "Tyrogue\0"
 .align 2,0
 
-.global MonsterCategorySmeargle
-MonsterCategorySmeargle:
+.global MonsterCategoryPainter
+MonsterCategoryPainter:
 .string "Painter\0"
 .align 2,0
 
@@ -1378,8 +1378,8 @@ MonsterNameSmeargle:
 .string "Smeargle\0"
 .align 2,0
 
-.global MonsterCategoryStantler
-MonsterCategoryStantler:
+.global MonsterCategoryBigHorn
+MonsterCategoryBigHorn:
 .string "Big Horn\0"
 .align 2,0
 
@@ -1393,8 +1393,8 @@ MonsterNamePorygon2:
 .string "Porygon2\0"
 .align 2,0
 
-.global MonsterCategoryDonphan
-MonsterCategoryDonphan:
+.global MonsterCategoryArmor
+MonsterCategoryArmor:
 .string "Armor\0"
 .align 2,0
 
@@ -1403,8 +1403,8 @@ MonsterNameDonphan:
 .string "Donphan\0"
 .align 2,0
 
-.global MonsterCategoryPhanpy
-MonsterCategoryPhanpy:
+.global MonsterCategoryLongNose
+MonsterCategoryLongNose:
 .string "Long Nose\0"
 .align 2,0
 
@@ -1423,8 +1423,8 @@ MonsterNameHoundoom:
 .string "Houndoom\0"
 .align 2,0
 
-.global MonsterCategoryHoundour
-MonsterCategoryHoundour:
+.global MonsterCategoryDark
+MonsterCategoryDark:
 .string "Dark\0"
 .align 2,0
 
@@ -1433,8 +1433,8 @@ MonsterNameHoundour:
 .string "Houndour\0"
 .align 2,0
 
-.global MonsterCategorySkarmory
-MonsterCategorySkarmory:
+.global MonsterCategoryArmorBird
+MonsterCategoryArmorBird:
 .string "Armor Bird\0"
 .align 2,0
 
@@ -1443,8 +1443,8 @@ MonsterNameSkarmory:
 .string "Skarmory\0"
 .align 2,0
 
-.global MonsterCategoryMantine
-MonsterCategoryMantine:
+.global MonsterCategoryKite
+MonsterCategoryKite:
 .string "Kite\0"
 .align 2,0
 
@@ -1453,8 +1453,8 @@ MonsterNameMantine:
 .string "Mantine\0"
 .align 2,0
 
-.global MonsterCategoryDelibird
-MonsterCategoryDelibird:
+.global MonsterCategoryDelivery
+MonsterCategoryDelivery:
 .string "Delivery\0"
 .align 2,0
 
@@ -1468,8 +1468,8 @@ MonsterNameOctillery:
 .string "Octillery\0"
 .align 2,0
 
-.global MonsterCategoryRemoraid
-MonsterCategoryRemoraid:
+.global MonsterCategoryJet
+MonsterCategoryJet:
 .string "Jet\0"
 .align 2,0
 
@@ -1478,8 +1478,8 @@ MonsterNameRemoraid:
 .string "Remoraid\0"
 .align 2,0
 
-.global MonsterCategoryCorsola
-MonsterCategoryCorsola:
+.global MonsterCategoryCoral
+MonsterCategoryCoral:
 .string "Coral\0"
 .align 2,0
 
@@ -1488,8 +1488,8 @@ MonsterNameCorsola:
 .string "Corsola\0"
 .align 2,0
 
-.global MonsterCategoryPiloswine
-MonsterCategoryPiloswine:
+.global MonsterCategorySwine
+MonsterCategorySwine:
 .string "Swine\0"
 .align 2,0
 
@@ -1498,8 +1498,8 @@ MonsterNamePiloswine:
 .string "Piloswine\0"
 .align 2,0
 
-.global MonsterCategorySwinub
-MonsterCategorySwinub:
+.global MonsterCategoryPig
+MonsterCategoryPig:
 .string "Pig\0"
 .align 2,0
 
@@ -1513,8 +1513,8 @@ MonsterNameMagcargo:
 .string "Magcargo\0"
 .align 2,0
 
-.global MonsterCategorySlugma
-MonsterCategorySlugma:
+.global MonsterCategoryLava
+MonsterCategoryLava:
 .string "Lava\0"
 .align 2,0
 
@@ -1523,8 +1523,8 @@ MonsterNameSlugma:
 .string "Slugma\0"
 .align 2,0
 
-.global MonsterCategoryUrsaring
-MonsterCategoryUrsaring:
+.global MonsterCategoryHibernator
+MonsterCategoryHibernator:
 .string "Hibernator\0"
 .align 2,0
 
@@ -1533,8 +1533,8 @@ MonsterNameUrsaring:
 .string "Ursaring\0"
 .align 2,0
 
-.global MonsterCategoryTeddiursa
-MonsterCategoryTeddiursa:
+.global MonsterCategoryLittleBear
+MonsterCategoryLittleBear:
 .string "Little Bear\0"
 .align 2,0
 
@@ -1543,8 +1543,8 @@ MonsterNameTeddiursa:
 .string "Teddiursa\0"
 .align 2,0
 
-.global MonsterCategorySneasel
-MonsterCategorySneasel:
+.global MonsterCategorySharpClaw
+MonsterCategorySharpClaw:
 .string "Sharp Claw\0"
 .align 2,0
 
@@ -1553,8 +1553,8 @@ MonsterNameSneasel:
 .string "Sneasel\0"
 .align 2,0
 
-.global MonsterCategoryHeracross
-MonsterCategoryHeracross:
+.global MonsterCategorySingleHorn
+MonsterCategorySingleHorn:
 .string "Single Horn\0"
 .align 2,0
 
@@ -1563,8 +1563,8 @@ MonsterNameHeracross:
 .string "Heracross\0"
 .align 2,0
 
-.global MonsterCategoryShuckle
-MonsterCategoryShuckle:
+.global MonsterCategoryMold
+MonsterCategoryMold:
 .string "Mold\0"
 .align 2,0
 
@@ -1593,8 +1593,8 @@ MonsterNameSnubbull:
 .string "Snubbull\0"
 .align 2,0
 
-.global MonsterCategorySteelix
-MonsterCategorySteelix:
+.global MonsterCategoryIronSnake
+MonsterCategoryIronSnake:
 .string "Iron Snake\0"
 .align 2,0
 
@@ -1603,8 +1603,8 @@ MonsterNameSteelix:
 .string "Steelix\0"
 .align 2,0
 
-.global MonsterCategoryGligar
-MonsterCategoryGligar:
+.global MonsterCategoryFlyscorpion
+MonsterCategoryFlyscorpion:
 .string "Flyscorpion\0"
 .align 2,0
 
@@ -1613,8 +1613,8 @@ MonsterNameGligar:
 .string "Gligar\0"
 .align 2,0
 
-.global MonsterCategoryDunsparce
-MonsterCategoryDunsparce:
+.global MonsterCategoryLandSnake
+MonsterCategoryLandSnake:
 .string "Land Snake\0"
 .align 2,0
 
@@ -1628,8 +1628,8 @@ MonsterNameForretress:
 .string "Forretress\0"
 .align 2,0
 
-.global MonsterCategoryPineco
-MonsterCategoryPineco:
+.global MonsterCategoryBagworm
+MonsterCategoryBagworm:
 .string "Bagworm\0"
 .align 2,0
 
@@ -1638,8 +1638,8 @@ MonsterNamePineco:
 .string "Pineco\0"
 .align 2,0
 
-.global MonsterCategoryGirafarig
-MonsterCategoryGirafarig:
+.global MonsterCategoryLongNeck
+MonsterCategoryLongNeck:
 .string "Long Neck\0"
 .align 2,0
 
@@ -1648,8 +1648,8 @@ MonsterNameGirafarig:
 .string "Girafarig\0"
 .align 2,0
 
-.global MonsterCategoryWobbuffet
-MonsterCategoryWobbuffet:
+.global MonsterCategoryPatient
+MonsterCategoryPatient:
 .string "Patient\0"
 .align 2,0
 
@@ -1658,8 +1658,8 @@ MonsterNameWobbuffet:
 .string "Wobbuffet\0"
 .align 2,0
 
-.global MonsterCategoryUnown
-MonsterCategoryUnown:
+.global MonsterCategorySymbol
+MonsterCategorySymbol:
 .string "Symbol\0"
 .align 2,0
 
@@ -1668,8 +1668,8 @@ MonsterNameUnown:
 .string "Unown\0"
 .align 2,0
 
-.global MonsterCategoryMisdreavus
-MonsterCategoryMisdreavus:
+.global MonsterCategoryScreech
+MonsterCategoryScreech:
 .string "Screech\0"
 .align 2,0
 
@@ -1678,8 +1678,8 @@ MonsterNameMisdreavus:
 .string "Misdreavus\0"
 .align 2,0
 
-.global MonsterCategorySlowking
-MonsterCategorySlowking:
+.global MonsterCategoryRoyal
+MonsterCategoryRoyal:
 .string "Royal\0"
 .align 2,0
 
@@ -1688,8 +1688,8 @@ MonsterNameSlowking:
 .string "Slowking\0"
 .align 2,0
 
-.global MonsterCategoryMurkrow
-MonsterCategoryMurkrow:
+.global MonsterCategoryDarkness
+MonsterCategoryDarkness:
 .string "Darkness\0"
 .align 2,0
 
@@ -1698,8 +1698,8 @@ MonsterNameMurkrow:
 .string "Murkrow\0"
 .align 2,0
 
-.global MonsterCategoryUmbreon
-MonsterCategoryUmbreon:
+.global MonsterCategoryMoonlight
+MonsterCategoryMoonlight:
 .string "Moonlight\0"
 .align 2,0
 
@@ -1718,8 +1718,8 @@ MonsterNameQuagsire:
 .string "Quagsire\0"
 .align 2,0
 
-.global MonsterCategoryWooper
-MonsterCategoryWooper:
+.global MonsterCategoryWaterFish
+MonsterCategoryWaterFish:
 .string "Water Fish\0"
 .align 2,0
 
@@ -1728,8 +1728,8 @@ MonsterNameWooper:
 .string "Wooper\0"
 .align 2,0
 
-.global MonsterCategoryYanma
-MonsterCategoryYanma:
+.global MonsterCategoryClearWing
+MonsterCategoryClearWing:
 .string "Clear Wing\0"
 .align 2,0
 
@@ -1738,8 +1738,8 @@ MonsterNameYanma:
 .string "Yanma\0"
 .align 2,0
 
-.global MonsterCategorySunflora
-MonsterCategorySunflora:
+.global MonsterCategorySun
+MonsterCategorySun:
 .string "Sun\0"
 .align 2,0
 
@@ -1753,8 +1753,8 @@ MonsterNameSunkern:
 .string "Sunkern\0"
 .align 2,0
 
-.global MonsterCategoryAipom
-MonsterCategoryAipom:
+.global MonsterCategoryLongTail
+MonsterCategoryLongTail:
 .string "Long Tail\0"
 .align 2,0
 
@@ -1773,8 +1773,8 @@ MonsterNameSkiploom:
 .string "Skiploom\0"
 .align 2,0
 
-.global MonsterCategoryHoppip
-MonsterCategoryHoppip:
+.global MonsterCategoryCottonweed
+MonsterCategoryCottonweed:
 .string "Cottonweed\0"
 .align 2,0
 
@@ -1783,8 +1783,8 @@ MonsterNameHoppip:
 .string "Hoppip\0"
 .align 2,0
 
-.global MonsterCategoryPolitoed
-MonsterCategoryPolitoed:
+.global MonsterCategoryFrog
+MonsterCategoryFrog:
 .string "Frog\0"
 .align 2,0
 
@@ -1793,8 +1793,8 @@ MonsterNamePolitoed:
 .string "Politoed\0"
 .align 2,0
 
-.global MonsterCategorySudowoodo
-MonsterCategorySudowoodo:
+.global MonsterCategoryImitation
+MonsterCategoryImitation:
 .string "Imitation\0"
 .align 2,0
 
@@ -1803,8 +1803,8 @@ MonsterNameSudowoodo:
 .string "Sudowoodo\0"
 .align 2,0
 
-.global MonsterCategoryAzumarill
-MonsterCategoryAzumarill:
+.global MonsterCategoryAquaRabbit
+MonsterCategoryAquaRabbit:
 .string "Aqua Rabbit\0"
 .align 2,0
 
@@ -1813,8 +1813,8 @@ MonsterNameAzumarill:
 .string "Azumarill\0"
 .align 2,0
 
-.global MonsterCategoryMarill
-MonsterCategoryMarill:
+.global MonsterCategoryAquaMouse
+MonsterCategoryAquaMouse:
 .string "Aqua Mouse\0"
 .align 2,0
 
@@ -1838,8 +1838,8 @@ MonsterNameFlaaffy:
 .string "Flaaffy\0"
 .align 2,0
 
-.global MonsterCategoryMareep
-MonsterCategoryMareep:
+.global MonsterCategoryWool
+MonsterCategoryWool:
 .string "Wool\0"
 .align 2,0
 
@@ -1848,8 +1848,8 @@ MonsterNameMareep:
 .string "Mareep\0"
 .align 2,0
 
-.global MonsterCategoryXatu
-MonsterCategoryXatu:
+.global MonsterCategoryMystic
+MonsterCategoryMystic:
 .string "Mystic\0"
 .align 2,0
 
@@ -1863,8 +1863,8 @@ MonsterNameNatu:
 .string "Natu\0"
 .align 2,0
 
-.global MonsterCategoryTogetic
-MonsterCategoryTogetic:
+.global MonsterCategoryHappiness
+MonsterCategoryHappiness:
 .string "Happiness\0"
 .align 2,0
 
@@ -1873,8 +1873,8 @@ MonsterNameTogetic:
 .string "Togetic\0"
 .align 2,0
 
-.global MonsterCategoryTogepi
-MonsterCategoryTogepi:
+.global MonsterCategorySpikeBall
+MonsterCategorySpikeBall:
 .string "Spike Ball\0"
 .align 2,0
 
@@ -1893,8 +1893,8 @@ MonsterNameCleffa:
 .string "Cleffa\0"
 .align 2,0
 
-.global MonsterCategoryPichu
-MonsterCategoryPichu:
+.global MonsterCategoryTinyMouse
+MonsterCategoryTinyMouse:
 .string "Tiny Mouse\0"
 .align 2,0
 
@@ -1903,8 +1903,8 @@ MonsterNamePichu:
 .string "Pichu\0"
 .align 2,0
 
-.global MonsterCategoryLanturn
-MonsterCategoryLanturn:
+.global MonsterCategoryLight
+MonsterCategoryLight:
 .string "Light\0"
 .align 2,0
 
@@ -1913,8 +1913,8 @@ MonsterNameLanturn:
 .string "Lanturn\0"
 .align 2,0
 
-.global MonsterCategoryChinchou
-MonsterCategoryChinchou:
+.global MonsterCategoryAngler
+MonsterCategoryAngler:
 .string "Angler\0"
 .align 2,0
 
@@ -1928,8 +1928,8 @@ MonsterNameCrobat:
 .string "Crobat\0"
 .align 2,0
 
-.global MonsterCategoryAriados
-MonsterCategoryAriados:
+.global MonsterCategoryLongLeg
+MonsterCategoryLongLeg:
 .string "Long Leg\0"
 .align 2,0
 
@@ -1938,8 +1938,8 @@ MonsterNameAriados:
 .string "Ariados\0"
 .align 2,0
 
-.global MonsterCategorySpinarak
-MonsterCategorySpinarak:
+.global MonsterCategoryStringSpit
+MonsterCategoryStringSpit:
 .string "String Spit\0"
 .align 2,0
 
@@ -1953,8 +1953,8 @@ MonsterNameLedian:
 .string "Ledian\0"
 .align 2,0
 
-.global MonsterCategoryLedyba
-MonsterCategoryLedyba:
+.global MonsterCategoryFiveStar
+MonsterCategoryFiveStar:
 .string "Five Star\0"
 .align 2,0
 
@@ -1968,8 +1968,8 @@ MonsterNameNoctowl:
 .string "Noctowl\0"
 .align 2,0
 
-.global MonsterCategoryHoothoot
-MonsterCategoryHoothoot:
+.global MonsterCategoryOwl
+MonsterCategoryOwl:
 .string "Owl\0"
 .align 2,0
 
@@ -1978,8 +1978,8 @@ MonsterNameHoothoot:
 .string "Hoothoot\0"
 .align 2,0
 
-.global MonsterCategoryFurret
-MonsterCategoryFurret:
+.global MonsterCategoryLongBody
+MonsterCategoryLongBody:
 .string "Long Body\0"
 .align 2,0
 
@@ -1988,8 +1988,8 @@ MonsterNameFurret:
 .string "Furret\0"
 .align 2,0
 
-.global MonsterCategorySentret
-MonsterCategorySentret:
+.global MonsterCategoryScout
+MonsterCategoryScout:
 .string "Scout\0"
 .align 2,0
 
@@ -2008,8 +2008,8 @@ MonsterNameCroconaw:
 .string "Croconaw\0"
 .align 2,0
 
-.global MonsterCategoryTotodile
-MonsterCategoryTotodile:
+.global MonsterCategoryBigJaw
+MonsterCategoryBigJaw:
 .string "Big Jaw\0"
 .align 2,0
 
@@ -2023,8 +2023,8 @@ MonsterNameTyphlosion:
 .string "Typhlosion\0"
 .align 2,0
 
-.global MonsterCategoryQuilava
-MonsterCategoryQuilava:
+.global MonsterCategoryVolcano
+MonsterCategoryVolcano:
 .string "Volcano\0"
 .align 2,0
 
@@ -2033,8 +2033,8 @@ MonsterNameQuilava:
 .string "Quilava\0"
 .align 2,0
 
-.global MonsterCategoryCyndaquil
-MonsterCategoryCyndaquil:
+.global MonsterCategoryFireMouse
+MonsterCategoryFireMouse:
 .string "Fire Mouse\0"
 .align 2,0
 
@@ -2043,8 +2043,8 @@ MonsterNameCyndaquil:
 .string "Cyndaquil\0"
 .align 2,0
 
-.global MonsterCategoryMeganium
-MonsterCategoryMeganium:
+.global MonsterCategoryHerb
+MonsterCategoryHerb:
 .string "Herb\0"
 .align 2,0
 
@@ -2058,8 +2058,8 @@ MonsterNameBayleef:
 .string "Bayleef\0"
 .align 2,0
 
-.global MonsterCategoryChikorita
-MonsterCategoryChikorita:
+.global MonsterCategoryLeaf
+MonsterCategoryLeaf:
 .string "Leaf\0"
 .align 2,0
 
@@ -2068,8 +2068,8 @@ MonsterNameChikorita:
 .string "Chikorita\0"
 .align 2,0
 
-.global MonsterCategoryMew
-MonsterCategoryMew:
+.global MonsterCategoryNewSpecies
+MonsterCategoryNewSpecies:
 .string "New Species\0"
 .align 2,0
 
@@ -2078,8 +2078,8 @@ MonsterNameMew:
 .string "Mew\0"
 .align 2,0
 
-.global MonsterCategoryMewtwo
-MonsterCategoryMewtwo:
+.global MonsterCategoryNewSpeciestwo
+MonsterCategoryNewSpeciestwo:
 .string "Genetic\0"
 .align 2,0
 
@@ -2113,8 +2113,8 @@ MonsterNameZapdos:
 .string "Zapdos\0"
 .align 2,0
 
-.global MonsterCategoryArticuno
-MonsterCategoryArticuno:
+.global MonsterCategoryFreeze
+MonsterCategoryFreeze:
 .string "Freeze\0"
 .align 2,0
 
@@ -2123,8 +2123,8 @@ MonsterNameArticuno:
 .string "Articuno\0"
 .align 2,0
 
-.global MonsterCategorySnorlax
-MonsterCategorySnorlax:
+.global MonsterCategorySleeping
+MonsterCategorySleeping:
 .string "Sleeping\0"
 .align 2,0
 
@@ -2133,8 +2133,8 @@ MonsterNameSnorlax:
 .string "Snorlax\0"
 .align 2,0
 
-.global MonsterCategoryAerodactyl
-MonsterCategoryAerodactyl:
+.global MonsterCategoryFossil
+MonsterCategoryFossil:
 .string "Fossil\0"
 .align 2,0
 
@@ -2158,8 +2158,8 @@ MonsterNameOmastar:
 .string "Omastar\0"
 .align 2,0
 
-.global MonsterCategoryOmanyte
-MonsterCategoryOmanyte:
+.global MonsterCategorySpiral
+MonsterCategorySpiral:
 .string "Spiral\0"
 .align 2,0
 
@@ -2168,8 +2168,8 @@ MonsterNameOmanyte:
 .string "Omanyte\0"
 .align 2,0
 
-.global MonsterCategoryPorygon
-MonsterCategoryPorygon:
+.global MonsterCategoryVirtual
+MonsterCategoryVirtual:
 .string "Virtual\0"
 .align 2,0
 
@@ -2183,8 +2183,8 @@ MonsterNameFlareon:
 .string "Flareon\0"
 .align 2,0
 
-.global MonsterCategoryJolteon
-MonsterCategoryJolteon:
+.global MonsterCategoryLightning
+MonsterCategoryLightning:
 .string "Lightning\0"
 .align 2,0
 
@@ -2193,8 +2193,8 @@ MonsterNameJolteon:
 .string "Jolteon\0"
 .align 2,0
 
-.global MonsterCategoryVaporeon
-MonsterCategoryVaporeon:
+.global MonsterCategoryBubbleJet
+MonsterCategoryBubbleJet:
 .string "Bubble Jet\0"
 .align 2,0
 
@@ -2203,8 +2203,8 @@ MonsterNameVaporeon:
 .string "Vaporeon\0"
 .align 2,0
 
-.global MonsterCategoryEevee
-MonsterCategoryEevee:
+.global MonsterCategoryEvolution
+MonsterCategoryEvolution:
 .string "Evolution\0"
 .align 2,0
 
@@ -2213,8 +2213,8 @@ MonsterNameEevee:
 .string "Eevee\0"
 .align 2,0
 
-.global MonsterCategoryDitto
-MonsterCategoryDitto:
+.global MonsterCategoryTransform
+MonsterCategoryTransform:
 .string "Transform\0"
 .align 2,0
 
@@ -2223,8 +2223,8 @@ MonsterNameDitto:
 .string "Ditto\0"
 .align 2,0
 
-.global MonsterCategoryLapras
-MonsterCategoryLapras:
+.global MonsterCategoryTransport
+MonsterCategoryTransport:
 .string "Transport\0"
 .align 2,0
 
@@ -2233,8 +2233,8 @@ MonsterNameLapras:
 .string "Lapras\0"
 .align 2,0
 
-.global MonsterCategoryGyarados
-MonsterCategoryGyarados:
+.global MonsterCategoryAtrocious
+MonsterCategoryAtrocious:
 .string "Atrocious\0"
 .align 2,0
 
@@ -2243,8 +2243,8 @@ MonsterNameGyarados:
 .string "Gyarados\0"
 .align 2,0
 
-.global MonsterCategoryMagikarp
-MonsterCategoryMagikarp:
+.global MonsterCategoryFish
+MonsterCategoryFish:
 .string "Fish\0"
 .align 2,0
 
@@ -2253,8 +2253,8 @@ MonsterNameMagikarp:
 .string "Magikarp\0"
 .align 2,0
 
-.global MonsterCategoryTauros
-MonsterCategoryTauros:
+.global MonsterCategoryWildBull
+MonsterCategoryWildBull:
 .string "Wild Bull\0"
 .align 2,0
 
@@ -2263,8 +2263,8 @@ MonsterNameTauros:
 .string "Tauros\0"
 .align 2,0
 
-.global MonsterCategoryPinsir
-MonsterCategoryPinsir:
+.global MonsterCategoryStagBeetle
+MonsterCategoryStagBeetle:
 .string "Stag Beetle\0"
 .align 2,0
 
@@ -2273,8 +2273,8 @@ MonsterNamePinsir:
 .string "Pinsir\0"
 .align 2,0
 
-.global MonsterCategoryMagmar
-MonsterCategoryMagmar:
+.global MonsterCategorySpitfire
+MonsterCategorySpitfire:
 .string "Spitfire\0"
 .align 2,0
 
@@ -2283,8 +2283,8 @@ MonsterNameMagmar:
 .string "Magmar\0"
 .align 2,0
 
-.global MonsterCategoryElectabuzz
-MonsterCategoryElectabuzz:
+.global MonsterCategoryElectric
+MonsterCategoryElectric:
 .string "Electric\0"
 .align 2,0
 
@@ -2293,8 +2293,8 @@ MonsterNameElectabuzz:
 .string "Electabuzz\0"
 .align 2,0
 
-.global MonsterCategoryJynx
-MonsterCategoryJynx:
+.global MonsterCategoryHumanShape
+MonsterCategoryHumanShape:
 .string "Human Shape\0"
 .align 2,0
 
@@ -2303,8 +2303,8 @@ MonsterNameJynx:
 .string "Jynx\0"
 .align 2,0
 
-.global MonsterCategoryScyther
-MonsterCategoryScyther:
+.global MonsterCategoryMantis
+MonsterCategoryMantis:
 .string "Mantis\0"
 .align 2,0
 
@@ -2313,8 +2313,8 @@ MonsterNameScyther:
 .string "Scyther\0"
 .align 2,0
 
-.global MonsterCategoryMrMime
-MonsterCategoryMrMime:
+.global MonsterCategoryBarrier
+MonsterCategoryBarrier:
 .string "Barrier\0"
 .align 2,0
 
@@ -2323,8 +2323,8 @@ MonsterNameMrMime:
 .string "Mr. Mime\0"
 .align 2,0
 
-.global MonsterCategoryStarmie
-MonsterCategoryStarmie:
+.global MonsterCategoryMysterious
+MonsterCategoryMysterious:
 .string "Mysterious\0"
 .align 2,0
 
@@ -2333,8 +2333,8 @@ MonsterNameStarmie:
 .string "Starmie\0"
 .align 2,0
 
-.global MonsterCategoryStaryu
-MonsterCategoryStaryu:
+.global MonsterCategoryStarShape
+MonsterCategoryStarShape:
 .string "Star Shape\0"
 .align 2,0
 
@@ -2348,8 +2348,8 @@ MonsterNameSeaking:
 .string "Seaking\0"
 .align 2,0
 
-.global MonsterCategoryGoldeen
-MonsterCategoryGoldeen:
+.global MonsterCategoryGoldfish
+MonsterCategoryGoldfish:
 .string "Goldfish\0"
 .align 2,0
 
@@ -2363,8 +2363,8 @@ MonsterNameSeadra:
 .string "Seadra\0"
 .align 2,0
 
-.global MonsterCategoryHorsea
-MonsterCategoryHorsea:
+.global MonsterCategoryDragon
+MonsterCategoryDragon:
 .string "Dragon\0"
 .align 2,0
 
@@ -2373,8 +2373,8 @@ MonsterNameHorsea:
 .string "Horsea\0"
 .align 2,0
 
-.global MonsterCategoryKangaskhan
-MonsterCategoryKangaskhan:
+.global MonsterCategoryParent
+MonsterCategoryParent:
 .string "Parent\0"
 .align 2,0
 
@@ -2383,8 +2383,8 @@ MonsterNameKangaskhan:
 .string "Kangaskhan\0"
 .align 2,0
 
-.global MonsterCategoryTangela
-MonsterCategoryTangela:
+.global MonsterCategoryVine
+MonsterCategoryVine:
 .string "Vine\0"
 .align 2,0
 
@@ -2403,8 +2403,8 @@ MonsterNameRhydon:
 .string "Rhydon\0"
 .align 2,0
 
-.global MonsterCategoryRhyhorn
-MonsterCategoryRhyhorn:
+.global MonsterCategorySpikes
+MonsterCategorySpikes:
 .string "Spikes\0"
 .align 2,0
 
@@ -2418,8 +2418,8 @@ MonsterNameWeezing:
 .string "Weezing\0"
 .align 2,0
 
-.global MonsterCategoryKoffing
-MonsterCategoryKoffing:
+.global MonsterCategoryPoisonGas
+MonsterCategoryPoisonGas:
 .string "Poison Gas\0"
 .align 2,0
 
@@ -2428,8 +2428,8 @@ MonsterNameKoffing:
 .string "Koffing\0"
 .align 2,0
 
-.global MonsterCategoryLickitung
-MonsterCategoryLickitung:
+.global MonsterCategoryLicking
+MonsterCategoryLicking:
 .string "Licking\0"
 .align 2,0
 
@@ -2438,8 +2438,8 @@ MonsterNameLickitung:
 .string "Lickitung\0"
 .align 2,0
 
-.global MonsterCategoryHitmonchan
-MonsterCategoryHitmonchan:
+.global MonsterCategoryPunching
+MonsterCategoryPunching:
 .string "Punching\0"
 .align 2,0
 
@@ -2448,8 +2448,8 @@ MonsterNameHitmonchan:
 .string "Hitmonchan\0"
 .align 2,0
 
-.global MonsterCategoryHitmonlee
-MonsterCategoryHitmonlee:
+.global MonsterCategoryKicking
+MonsterCategoryKicking:
 .string "Kicking\0"
 .align 2,0
 
@@ -2458,8 +2458,8 @@ MonsterNameHitmonlee:
 .string "Hitmonlee\0"
 .align 2,0
 
-.global MonsterCategoryMarowak
-MonsterCategoryMarowak:
+.global MonsterCategoryBoneKeeper
+MonsterCategoryBoneKeeper:
 .string "Bone Keeper\0"
 .align 2,0
 
@@ -2468,8 +2468,8 @@ MonsterNameMarowak:
 .string "Marowak\0"
 .align 2,0
 
-.global MonsterCategoryCubone
-MonsterCategoryCubone:
+.global MonsterCategoryLonely
+MonsterCategoryLonely:
 .string "Lonely\0"
 .align 2,0
 
@@ -2478,8 +2478,8 @@ MonsterNameCubone:
 .string "Cubone\0"
 .align 2,0
 
-.global MonsterCategoryExeggutor
-MonsterCategoryExeggutor:
+.global MonsterCategoryCoconut
+MonsterCategoryCoconut:
 .string "Coconut\0"
 .align 2,0
 
@@ -2488,8 +2488,8 @@ MonsterNameExeggutor:
 .string "Exeggutor\0"
 .align 2,0
 
-.global MonsterCategoryExeggcute
-MonsterCategoryExeggcute:
+.global MonsterCategoryEgg
+MonsterCategoryEgg:
 .string "Egg\0"
 .align 2,0
 
@@ -2503,8 +2503,8 @@ MonsterNameElectrode:
 .string "Electrode\0"
 .align 2,0
 
-.global MonsterCategoryVoltorb
-MonsterCategoryVoltorb:
+.global MonsterCategoryBall
+MonsterCategoryBall:
 .string "Ball\0"
 .align 2,0
 
@@ -2513,8 +2513,8 @@ MonsterNameVoltorb:
 .string "Voltorb\0"
 .align 2,0
 
-.global MonsterCategoryKingler
-MonsterCategoryKingler:
+.global MonsterCategoryPincer
+MonsterCategoryPincer:
 .string "Pincer\0"
 .align 2,0
 
@@ -2523,8 +2523,8 @@ MonsterNameKingler:
 .string "Kingler\0"
 .align 2,0
 
-.global MonsterCategoryKrabby
-MonsterCategoryKrabby:
+.global MonsterCategoryRiverCrab
+MonsterCategoryRiverCrab:
 .string "River Crab\0"
 .align 2,0
 
@@ -2538,8 +2538,8 @@ MonsterNameHypno:
 .string "Hypno\0"
 .align 2,0
 
-.global MonsterCategoryDrowzee
-MonsterCategoryDrowzee:
+.global MonsterCategoryHypnosis
+MonsterCategoryHypnosis:
 .string "Hypnosis\0"
 .align 2,0
 
@@ -2548,8 +2548,8 @@ MonsterNameDrowzee:
 .string "Drowzee\0"
 .align 2,0
 
-.global MonsterCategoryOnix
-MonsterCategoryOnix:
+.global MonsterCategoryRockSnake
+MonsterCategoryRockSnake:
 .string "Rock Snake\0"
 .align 2,0
 
@@ -2558,8 +2558,8 @@ MonsterNameOnix:
 .string "Onix\0"
 .align 2,0
 
-.global MonsterCategoryGengar
-MonsterCategoryGengar:
+.global MonsterCategoryShadow
+MonsterCategoryShadow:
 .string "Shadow\0"
 .align 2,0
 
@@ -2573,8 +2573,8 @@ MonsterNameHaunter:
 .string "Haunter\0"
 .align 2,0
 
-.global MonsterCategoryGastly
-MonsterCategoryGastly:
+.global MonsterCategoryGas
+MonsterCategoryGas:
 .string "Gas\0"
 .align 2,0
 
@@ -2588,8 +2588,8 @@ MonsterNameCloyster:
 .string "Cloyster\0"
 .align 2,0
 
-.global MonsterCategoryShellder
-MonsterCategoryShellder:
+.global MonsterCategoryBivalve
+MonsterCategoryBivalve:
 .string "Bivalve\0"
 .align 2,0
 
@@ -2603,8 +2603,8 @@ MonsterNameMuk:
 .string "Muk\0"
 .align 2,0
 
-.global MonsterCategoryGrimer
-MonsterCategoryGrimer:
+.global MonsterCategorySludge
+MonsterCategorySludge:
 .string "Sludge\0"
 .align 2,0
 
@@ -2618,8 +2618,8 @@ MonsterNameDewgong:
 .string "Dewgong\0"
 .align 2,0
 
-.global MonsterCategorySeel
-MonsterCategorySeel:
+.global MonsterCategorySeaLion
+MonsterCategorySeaLion:
 .string "Sea Lion\0"
 .align 2,0
 
@@ -2628,8 +2628,8 @@ MonsterNameSeel:
 .string "Seel\0"
 .align 2,0
 
-.global MonsterCategoryDodrio
-MonsterCategoryDodrio:
+.global MonsterCategoryTripleBird
+MonsterCategoryTripleBird:
 .string "Triple Bird\0"
 .align 2,0
 
@@ -2638,8 +2638,8 @@ MonsterNameDodrio:
 .string "Dodrio\0"
 .align 2,0
 
-.global MonsterCategoryDoduo
-MonsterCategoryDoduo:
+.global MonsterCategoryTwinBird
+MonsterCategoryTwinBird:
 .string "Twin Bird\0"
 .align 2,0
 
@@ -2648,8 +2648,8 @@ MonsterNameDoduo:
 .string "Doduo\0"
 .align 2,0
 
-.global MonsterCategoryFarfetch
-MonsterCategoryFarfetch:
+.global MonsterCategoryWildDuck
+MonsterCategoryWildDuck:
 .string "Wild Duck\0"
 .align 2,0
 
@@ -2663,8 +2663,8 @@ MonsterNameMagneton:
 .string "Magneton\0"
 .align 2,0
 
-.global MonsterCategoryMagnemite
-MonsterCategoryMagnemite:
+.global MonsterCategoryMagnet
+MonsterCategoryMagnet:
 .string "Magnet\0"
 .align 2,0
 
@@ -2673,8 +2673,8 @@ MonsterNameMagnemite:
 .string "Magnemite\0"
 .align 2,0
 
-.global MonsterCategorySlowbro
-MonsterCategorySlowbro:
+.global MonsterCategoryHermitCrab
+MonsterCategoryHermitCrab:
 .string "Hermit Crab\0"
 .align 2,0
 
@@ -2683,8 +2683,8 @@ MonsterNameSlowbro:
 .string "Slowbro\0"
 .align 2,0
 
-.global MonsterCategorySlowpoke
-MonsterCategorySlowpoke:
+.global MonsterCategoryDopey
+MonsterCategoryDopey:
 .string "Dopey\0"
 .align 2,0
 
@@ -2698,8 +2698,8 @@ MonsterNameRapidash:
 .string "Rapidash\0"
 .align 2,0
 
-.global MonsterCategoryPonyta
-MonsterCategoryPonyta:
+.global MonsterCategoryFireHorse
+MonsterCategoryFireHorse:
 .string "Fire Horse\0"
 .align 2,0
 
@@ -2708,8 +2708,8 @@ MonsterNamePonyta:
 .string "Ponyta\0"
 .align 2,0
 
-.global MonsterCategoryGolem
-MonsterCategoryGolem:
+.global MonsterCategoryMegaton
+MonsterCategoryMegaton:
 .string "Megaton\0"
 .align 2,0
 
@@ -2723,8 +2723,8 @@ MonsterNameGraveler:
 .string "Graveler\0"
 .align 2,0
 
-.global MonsterCategoryGeodude
-MonsterCategoryGeodude:
+.global MonsterCategoryRock
+MonsterCategoryRock:
 .string "Rock\0"
 .align 2,0
 
@@ -2738,8 +2738,8 @@ MonsterNameTentacruel:
 .string "Tentacruel\0"
 .align 2,0
 
-.global MonsterCategoryTentacool
-MonsterCategoryTentacool:
+.global MonsterCategoryJellyfish
+MonsterCategoryJellyfish:
 .string "Jellyfish\0"
 .align 2,0
 
@@ -2753,8 +2753,8 @@ MonsterNameVictreebel:
 .string "Victreebel\0"
 .align 2,0
 
-.global MonsterCategoryWeepinbell
-MonsterCategoryWeepinbell:
+.global MonsterCategoryFlycatcher
+MonsterCategoryFlycatcher:
 .string "Flycatcher\0"
 .align 2,0
 
@@ -2778,8 +2778,8 @@ MonsterNameMachoke:
 .string "Machoke\0"
 .align 2,0
 
-.global MonsterCategoryMachop
-MonsterCategoryMachop:
+.global MonsterCategorySuperpower
+MonsterCategorySuperpower:
 .string "Superpower\0"
 .align 2,0
 
@@ -2798,8 +2798,8 @@ MonsterNameKadabra:
 .string "Kadabra\0"
 .align 2,0
 
-.global MonsterCategoryAbra
-MonsterCategoryAbra:
+.global MonsterCategoryPsi
+MonsterCategoryPsi:
 .string "Psi\0"
 .align 2,0
 
@@ -2818,8 +2818,8 @@ MonsterNamePoliwhirl:
 .string "Poliwhirl\0"
 .align 2,0
 
-.global MonsterCategoryPoliwag
-MonsterCategoryPoliwag:
+.global MonsterCategoryTadpole
+MonsterCategoryTadpole:
 .string "Tadpole\0"
 .align 2,0
 
@@ -2828,8 +2828,8 @@ MonsterNamePoliwag:
 .string "Poliwag\0"
 .align 2,0
 
-.global MonsterCategoryArcanine
-MonsterCategoryArcanine:
+.global MonsterCategoryLegendary
+MonsterCategoryLegendary:
 .string "Legendary\0"
 .align 2,0
 
@@ -2838,8 +2838,8 @@ MonsterNameArcanine:
 .string "Arcanine\0"
 .align 2,0
 
-.global MonsterCategoryGrowlithe
-MonsterCategoryGrowlithe:
+.global MonsterCategoryPuppy
+MonsterCategoryPuppy:
 .string "Puppy\0"
 .align 2,0
 
@@ -2853,8 +2853,8 @@ MonsterNamePrimeape:
 .string "Primeape\0"
 .align 2,0
 
-.global MonsterCategoryMankey
-MonsterCategoryMankey:
+.global MonsterCategoryPigMonkey
+MonsterCategoryPigMonkey:
 .string "Pig Monkey\0"
 .align 2,0
 
@@ -2868,8 +2868,8 @@ MonsterNameGolduck:
 .string "Golduck\0"
 .align 2,0
 
-.global MonsterCategoryPsyduck
-MonsterCategoryPsyduck:
+.global MonsterCategoryDuck
+MonsterCategoryDuck:
 .string "Duck\0"
 .align 2,0
 
@@ -2878,8 +2878,8 @@ MonsterNamePsyduck:
 .string "Psyduck\0"
 .align 2,0
 
-.global MonsterCategoryPersian
-MonsterCategoryPersian:
+.global MonsterCategoryClassyCat
+MonsterCategoryClassyCat:
 .string "Classy Cat\0"
 .align 2,0
 
@@ -2888,8 +2888,8 @@ MonsterNamePersian:
 .string "Persian\0"
 .align 2,0
 
-.global MonsterCategoryMeowth
-MonsterCategoryMeowth:
+.global MonsterCategoryScratchCat
+MonsterCategoryScratchCat:
 .string "Scratch Cat\0"
 .align 2,0
 
@@ -2903,8 +2903,8 @@ MonsterNameDugtrio:
 .string "Dugtrio\0"
 .align 2,0
 
-.global MonsterCategoryDiglett
-MonsterCategoryDiglett:
+.global MonsterCategoryMole
+MonsterCategoryMole:
 .string "Mole\0"
 .align 2,0
 
@@ -2913,8 +2913,8 @@ MonsterNameDiglett:
 .string "Diglett\0"
 .align 2,0
 
-.global MonsterCategoryVenomoth
-MonsterCategoryVenomoth:
+.global MonsterCategoryPoisonMoth
+MonsterCategoryPoisonMoth:
 .string "Poison Moth\0"
 .align 2,0
 
@@ -2923,8 +2923,8 @@ MonsterNameVenomoth:
 .string "Venomoth\0"
 .align 2,0
 
-.global MonsterCategoryVenonat
-MonsterCategoryVenonat:
+.global MonsterCategoryInsect
+MonsterCategoryInsect:
 .string "Insect\0"
 .align 2,0
 
@@ -2938,8 +2938,8 @@ MonsterNameParasect:
 .string "Parasect\0"
 .align 2,0
 
-.global MonsterCategoryParas
-MonsterCategoryParas:
+.global MonsterCategoryMushroom
+MonsterCategoryMushroom:
 .string "Mushroom\0"
 .align 2,0
 
@@ -2948,8 +2948,8 @@ MonsterNameParas:
 .string "Paras\0"
 .align 2,0
 
-.global MonsterCategoryVileplume
-MonsterCategoryVileplume:
+.global MonsterCategoryFlower
+MonsterCategoryFlower:
 .string "Flower\0"
 .align 2,0
 
@@ -2963,8 +2963,8 @@ MonsterNameGloom:
 .string "Gloom\0"
 .align 2,0
 
-.global MonsterCategoryOddish
-MonsterCategoryOddish:
+.global MonsterCategoryWeed
+MonsterCategoryWeed:
 .string "Weed\0"
 .align 2,0
 
@@ -2978,8 +2978,8 @@ MonsterNameGolbat:
 .string "Golbat\0"
 .align 2,0
 
-.global MonsterCategoryZubat
-MonsterCategoryZubat:
+.global MonsterCategoryBat
+MonsterCategoryBat:
 .string "Bat\0"
 .align 2,0
 
@@ -2993,8 +2993,8 @@ MonsterNameWigglytuff:
 .string "Wigglytuff\0"
 .align 2,0
 
-.global MonsterCategoryJigglypuff
-MonsterCategoryJigglypuff:
+.global MonsterCategoryBalloon
+MonsterCategoryBalloon:
 .string "Balloon\0"
 .align 2,0
 
@@ -3008,8 +3008,8 @@ MonsterNameNinetales:
 .string "Ninetales\0"
 .align 2,0
 
-.global MonsterCategoryVulpix
-MonsterCategoryVulpix:
+.global MonsterCategoryFox
+MonsterCategoryFox:
 .string "Fox\0"
 .align 2,0
 
@@ -3023,8 +3023,8 @@ MonsterNameClefable:
 .string "Clefable\0"
 .align 2,0
 
-.global MonsterCategoryClefairy
-MonsterCategoryClefairy:
+.global MonsterCategoryFairy
+MonsterCategoryFairy:
 .string "Fairy\0"
 .align 2,0
 
@@ -3048,8 +3048,8 @@ MonsterNameNidoran_M:
 .string "Nidoran♂\0"
 .align 2,0
 
-.global MonsterCategoryNidoqueen
-MonsterCategoryNidoqueen:
+.global MonsterCategoryDrill
+MonsterCategoryDrill:
 .string "Drill\0"
 .align 2,0
 
@@ -3063,8 +3063,8 @@ MonsterNameNidorina:
 .string "Nidorina\0"
 .align 2,0
 
-.global MonsterCategoryNidoran_F
-MonsterCategoryNidoran_F:
+.global MonsterCategoryPoisonPin
+MonsterCategoryPoisonPin:
 .string "Poison Pin\0"
 .align 2,0
 
@@ -3093,8 +3093,8 @@ MonsterNamePikachu:
 .string "Pikachu\0"
 .align 2,0
 
-.global MonsterCategoryArbok
-MonsterCategoryArbok:
+.global MonsterCategoryCobra
+MonsterCategoryCobra:
 .string "Cobra\0"
 .align 2,0
 
@@ -3103,8 +3103,8 @@ MonsterNameArbok:
 .string "Arbok\0"
 .align 2,0
 
-.global MonsterCategoryEkans
-MonsterCategoryEkans:
+.global MonsterCategorySnake
+MonsterCategorySnake:
 .string "Snake\0"
 .align 2,0
 
@@ -3113,8 +3113,8 @@ MonsterNameEkans:
 .string "Ekans\0"
 .align 2,0
 
-.global MonsterCategoryFearow
-MonsterCategoryFearow:
+.global MonsterCategoryBeak
+MonsterCategoryBeak:
 .string "Beak\0"
 .align 2,0
 
@@ -3133,8 +3133,8 @@ MonsterNameRaticate:
 .string "Raticate\0"
 .align 2,0
 
-.global MonsterCategoryRattata
-MonsterCategoryRattata:
+.global MonsterCategoryMouse
+MonsterCategoryMouse:
 .string "Mouse\0"
 .align 2,0
 
@@ -3148,8 +3148,8 @@ MonsterNamePidgeot:
 .string "Pidgeot\0"
 .align 2,0
 
-.global MonsterCategoryPidgeotto
-MonsterCategoryPidgeotto:
+.global MonsterCategoryBird
+MonsterCategoryBird:
 .string "Bird\0"
 .align 2,0
 
@@ -3158,8 +3158,8 @@ MonsterNamePidgeotto:
 .string "Pidgeotto\0"
 .align 2,0
 
-.global MonsterCategoryPidgey
-MonsterCategoryPidgey:
+.global MonsterCategoryTinyBird
+MonsterCategoryTinyBird:
 .string "Tiny Bird\0"
 .align 2,0
 
@@ -3168,8 +3168,8 @@ MonsterNamePidgey:
 .string "Pidgey\0"
 .align 2,0
 
-.global MonsterCategoryBeedrill
-MonsterCategoryBeedrill:
+.global MonsterCategoryPoisonBee
+MonsterCategoryPoisonBee:
 .string "Poison Bee\0"
 .align 2,0
 
@@ -3183,8 +3183,8 @@ MonsterNameKakuna:
 .string "Kakuna\0"
 .align 2,0
 
-.global MonsterCategoryWeedle
-MonsterCategoryWeedle:
+.global MonsterCategoryHairyBug
+MonsterCategoryHairyBug:
 .string "Hairy Bug\0"
 .align 2,0
 
@@ -3193,8 +3193,8 @@ MonsterNameWeedle:
 .string "Weedle\0"
 .align 2,0
 
-.global MonsterCategoryButterfree
-MonsterCategoryButterfree:
+.global MonsterCategoryButterfly
+MonsterCategoryButterfly:
 .string "Butterfly\0"
 .align 2,0
 
@@ -3203,8 +3203,8 @@ MonsterNameButterfree:
 .string "Butterfree\0"
 .align 2,0
 
-.global MonsterCategoryMetapod
-MonsterCategoryMetapod:
+.global MonsterCategoryCocoon
+MonsterCategoryCocoon:
 .string "Cocoon\0"
 .align 2,0
 
@@ -3213,8 +3213,8 @@ MonsterNameMetapod:
 .string "Metapod\0"
 .align 2,0
 
-.global MonsterCategoryCaterpie
-MonsterCategoryCaterpie:
+.global MonsterCategoryWorm
+MonsterCategoryWorm:
 .string "Worm\0"
 .align 2,0
 
@@ -3223,8 +3223,8 @@ MonsterNameCaterpie:
 .string "Caterpie\0"
 .align 2,0
 
-.global MonsterCategoryBlastoise
-MonsterCategoryBlastoise:
+.global MonsterCategoryShellfish
+MonsterCategoryShellfish:
 .string "Shellfish\0"
 .align 2,0
 
@@ -3233,8 +3233,8 @@ MonsterNameBlastoise:
 .string "Blastoise\0"
 .align 2,0
 
-.global MonsterCategoryWartortle
-MonsterCategoryWartortle:
+.global MonsterCategoryTurtle
+MonsterCategoryTurtle:
 .string "Turtle\0"
 .align 2,0
 
@@ -3243,8 +3243,8 @@ MonsterNameWartortle:
 .string "Wartortle\0"
 .align 2,0
 
-.global MonsterCategorySquirtle
-MonsterCategorySquirtle:
+.global MonsterCategoryTinyTurtle
+MonsterCategoryTinyTurtle:
 .string "Tiny Turtle\0"
 .align 2,0
 
@@ -3258,8 +3258,8 @@ MonsterNameCharizard:
 .string "Charizard\0"
 .align 2,0
 
-.global MonsterCategoryCharmeleon
-MonsterCategoryCharmeleon:
+.global MonsterCategoryFlame
+MonsterCategoryFlame:
 .string "Flame\0"
 .align 2,0
 
@@ -3268,8 +3268,8 @@ MonsterNameCharmeleon:
 .string "Charmeleon\0"
 .align 2,0
 
-.global MonsterCategoryCharmander
-MonsterCategoryCharmander:
+.global MonsterCategoryLizard
+MonsterCategoryLizard:
 .string "Lizard\0"
 .align 2,0
 
@@ -3288,8 +3288,8 @@ MonsterNameIvysaur:
 .string "Ivysaur\0"
 .align 2,0
 
-.global MonsterCategoryBulbasaur
-MonsterCategoryBulbasaur:
+.global MonsterCategorySeed
+MonsterCategorySeed:
 .string "Seed\0"
 .align 2,0
 
@@ -3298,8 +3298,8 @@ MonsterNameBulbasaur:
 .string "Bulbasaur\0"
 .align 2,0
 
-.global MonsterCategoryNone
-MonsterCategoryNone:
+.global MonsterCategoryEruption
+MonsterCategoryEruption:
 .string "Eruption\0"
 .align 2,0
 

--- a/data/monster/monster_names.s
+++ b/data/monster/monster_names.s
@@ -2078,8 +2078,8 @@ MonsterNameMew:
 .string "Mew\0"
 .align 2,0
 
-.global MonsterCategoryNewSpeciestwo
-MonsterCategoryNewSpeciestwo:
+.global MonsterCategoryGenetic
+MonsterCategoryGenetic:
 .string "Genetic\0"
 .align 2,0
 

--- a/data/move/move_data.json
+++ b/data/move/move_data.json
@@ -515,7 +515,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryMisdreavus",
+        "name": "MonsterCategoryScreech",
         "basePower": 2,
         "type": "TYPE_NORMAL",
         "targetingFlags": "0b0000000010000000",
@@ -1210,7 +1210,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryPoochyena",
+        "name": "MonsterCategoryBite",
         "basePower": 7,
         "type": "TYPE_DARK",
         "targetingFlags": "0b0000000000000000",
@@ -1231,7 +1231,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryRaikou",
+        "name": "MonsterCategoryThunder",
         "basePower": 24,
         "type": "TYPE_ELECTRIC",
         "targetingFlags": "0b0000000000000000",
@@ -2151,7 +2151,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryDrowzee",
+        "name": "MonsterCategoryHypnosis",
         "basePower": 2,
         "type": "TYPE_PSYCHIC",
         "targetingFlags": "0b0000000010000000",
@@ -3362,7 +3362,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryUmbreon",
+        "name": "MonsterCategoryMoonlight",
         "basePower": 2,
         "type": "TYPE_NORMAL",
         "targetingFlags": "0b0000001001100001",
@@ -3401,7 +3401,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryHariyama",
+        "name": "MonsterCategoryArmThrust",
         "basePower": 2,
         "type": "TYPE_FIGHTING",
         "targetingFlags": "0b0000000000000000",
@@ -3808,7 +3808,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryKoffing",
+        "name": "MonsterCategoryPoisonGas",
         "basePower": 2,
         "type": "TYPE_POISON",
         "targetingFlags": "0b0000000000000000",
@@ -3984,7 +3984,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategorySpoink",
+        "name": "MonsterCategoryBounce",
         "basePower": 16,
         "type": "TYPE_FLYING",
         "targetingFlags": "0b0000000001110100",
@@ -4372,7 +4372,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryJirachi",
+        "name": "MonsterCategoryWish",
         "basePower": 2,
         "type": "TYPE_NORMAL",
         "targetingFlags": "0b0000000001110011",
@@ -4586,7 +4586,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategorySwellow",
+        "name": "MonsterCategorySwallow",
         "basePower": 2,
         "type": "TYPE_NORMAL",
         "targetingFlags": "0b0000001001110011",
@@ -4725,7 +4725,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryMachop",
+        "name": "MonsterCategorySuperpower",
         "basePower": 24,
         "type": "TYPE_FIGHTING",
         "targetingFlags": "0b0000000000000000",
@@ -5016,7 +5016,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryMrMime",
+        "name": "MonsterCategoryBarrier",
         "basePower": 2,
         "type": "TYPE_PSYCHIC",
         "targetingFlags": "0b0000000001110011",
@@ -5404,7 +5404,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryNone",
+        "name": "MonsterCategoryEruption",
         "basePower": 30,
         "type": "TYPE_FIRE",
         "targetingFlags": "0b0000000010000000",
@@ -5424,7 +5424,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryGrimer",
+        "name": "MonsterCategorySludge",
         "basePower": 12,
         "type": "TYPE_POISON",
         "targetingFlags": "0b0000000010000000",
@@ -5483,7 +5483,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryDitto",
+        "name": "MonsterCategoryTransform",
         "basePower": 2,
         "type": "TYPE_NORMAL",
         "targetingFlags": "0b0000000001110011",
@@ -5735,7 +5735,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryRhyhorn",
+        "name": "MonsterCategorySpikes",
         "basePower": 2,
         "type": "TYPE_GROUND",
         "targetingFlags": "0b0000000001110011",
@@ -6467,7 +6467,7 @@
         "useText": "MoveUseTextUse"
     },
     {
-        "name": "MonsterCategoryMeditite",
+        "name": "MonsterCategoryMeditate",
         "basePower": 2,
         "type": "TYPE_PSYCHIC",
         "targetingFlags": "0b0000000001110011",


### PR DESCRIPTION
Entrees like


```
        "name": "MonsterNameSpearow",
        "category": "MonsterCategoryPidgey",
``` 
and
```
        "name": "MonsterNameRaichu",
        "category": "MonsterCategoryRattata",
```

are confusing and look like typos. This change fixes the names to be explicit.

Bonus: `MonsterCategoryNone` maps to the string `Eruption`. I think calling it `None` is incorrect.