### PR TITLE
Fixed NONMATCHINGs breaking the build

### DIFF
--- a/src/code_8048480.c
+++ b/src/code_8048480.c
@@ -37,7 +37,7 @@ extern s16 gUnknown_80F4FBC;
 extern s16 gUnknown_80F4FBE;
 extern s16 gUnknown_80F4F46; // 0xC
 extern s16 gUnknown_80F4FA2;
-extern s16 gUnknown_80F4FA4; // 0x14 
+extern s16 gUnknown_80F4FA4; // 0x14
 extern s16 gUnknown_80F4FA6; // 0x2D
 extern s16 gUnknown_80F4FA8; // 0xF
 extern s16 gUnknown_80F4FAA; // 0x1E
@@ -169,7 +169,7 @@ extern void sub_8042390(Entity *, Item *);
 bool8 sub_8047930(Entity *pokemon, Entity *target)
 {
   bool8 flag;
-  
+
   if (((target->info->shopkeeper == TRUE) ||
       (target->info->clientType == 4)) || (target->info->clientType == CLIENT_TYPE_CLIENT)) {
     return FALSE;
@@ -203,7 +203,7 @@ void sub_80479B8(char param_1, char param_2, u8 param_3, Entity *pokemon, Entity
   u8 uStack_24;
   u8 uStack_23;
   u8 auStack_22;
-  
+
   if (param_1 != '\0') {
     if (param_2 == '\0') {
       flag = FALSE;
@@ -251,7 +251,7 @@ void sub_80479B8(char param_1, char param_2, u8 param_3, Entity *pokemon, Entity
     else goto _jump;
   }
   else {
-    if (param_1 == 0) 
+    if (param_1 == 0)
 _jump:
         sub_804245C(target,item);
   }
@@ -329,7 +329,7 @@ _jump:
         break;
       case ITEM_WARP_SEED:
         WarpSeedItemAction(pokemon,target);
-        break;      
+        break;
       case ITEM_SLEEP_SEED:
         SleepSeedItemAction(pokemon,target);
         break;
@@ -341,10 +341,10 @@ _jump:
         break;
       case ITEM_DOOM_SEED:
         DoomSeedItemAction(pokemon,target);
-        break;   
+        break;
        case ITEM_STUN_SEED:
         StunSeedItemAction(pokemon,target);
-        break;      
+        break;
       case ITEM_PLAIN_SEED:
         PlainSeedItemAction(pokemon,target);
         break;
@@ -456,7 +456,7 @@ _jump:
         break;
       case ITEM_STEEL_PART:
         SteelPartItemAction(pokemon,target,param_1);
-        break;  
+        break;
       case ITEM_WISH_STONE:
         WishStoneItemAction(pokemon,target,param_1);
         break;
@@ -467,7 +467,7 @@ _jump:
         if (param_1 != '\0') {
             sub_806F370(pokemon,target,gUnknown_80F4FAC,1,&auStack_22,0,0x217,0,0,0);
         }
-        else 
+        else
         {
             sub_80522F4(pokemon,target,*gUnknown_80FE458);
         }
@@ -479,7 +479,7 @@ _080482B4:
 
 UNUSED void nullsub_205(void) { }
 
-void SleepSeedItemAction(Entity *pokemon, Entity *target) 
+void SleepSeedItemAction(Entity *pokemon, Entity *target)
 {
     sub_8075C58(pokemon, target, CalculateStatusTurns(target, gUnknown_80F4E74, TRUE), TRUE);
 }
@@ -697,7 +697,7 @@ void BlastSeedItemAction(Entity *pokemon, Entity * target, u8 param_3)
   EntityInfo *entityInfo_1;
   Entity *entity;
   u8 auStack28 [4];
-  
+
   if (param_3 != 0) {
     entityInfo = target->info;
     entityInfo_1 = entityInfo;
@@ -764,7 +764,7 @@ void HandleGummiItemAction(Entity *pokemon, Entity *target, u8 gummiIndex)
   s32 iVar4;
   s32 iVar5;
   s32 currIQ;
-    
+
   targetInfo = target->info;
   gummiBoost = gTypeGummiIQBoost[targetInfo->types[0]][gummiIndex];
   gummiBoost += gTypeGummiIQBoost[targetInfo->types[1]][gummiIndex];
@@ -914,7 +914,7 @@ bool8 sub_8048A68(Entity *param_1,Item *item)
   EntityInfo *pEVar6;
   s32 index;
   PokemonStruct2 *pokemon;
-  
+
   if ((item->flags & ITEM_FLAG_STICKY)) {
     PrintFieldMessage(0,*gUnknown_80FE3E8,1);
     return FALSE;
@@ -939,9 +939,9 @@ bool8 sub_8048A68(Entity *param_1,Item *item)
           {
              pokemon = &gRecruitedPokemonRef->pokemon2[pEVar6->teamIndex];
              if (sub_806A538(pokemon->unkA))
-                 flag =  FALSE;   
+                 flag =  FALSE;
           }
-            
+
           if (CannotMove(entity, FALSE)) {
             flag = FALSE;
           }
@@ -1000,7 +1000,7 @@ bool32 sub_8048B9C(Entity *entity,Item *param_2)
   ActionContainer *actionPointer;
   ActionContainer actionContainer;
   u16 action;
-  
+
   bVar2 = FALSE;
   entityInfo = entity->info;
   actionPointer = &(entityInfo->action);
@@ -1076,7 +1076,7 @@ _clear:
                 SetMonsterActionFields(actionPointer,0x2c);
                 break;
               }
-          } 
+          }
           else
           {
                sub_8044C10(TRUE);
@@ -1084,7 +1084,7 @@ _clear:
           }
         }
         goto _load;
-      } 
+      }
     }
   }
   return bVar2;
@@ -1095,7 +1095,7 @@ bool8 sub_8048D50(Entity * pokemon, Item *item)
   EntityInfo *entityInfo;
 
   entityInfo = pokemon->info;
-  
+
   if ((item->flags & ITEM_FLAG_STICKY) != 0) {
     sub_8045BF8(gUnknown_202DE58, item);
     SendMessage(pokemon,*gUnknown_80FE3E8);
@@ -1142,7 +1142,7 @@ void GrimyFoodItemAction(Entity *pokemon, Entity * target)
             LowerAttackStageTarget(pokemon, target, gUnknown_8106A4C, 3, 1, TRUE);
             LowerAttackStageTarget(pokemon, target, gUnknown_8106A50, 3, 1, TRUE);
             break;
-    } 
+    }
 }
 
 void IcePartItemAction(Entity *pokemon, Entity *target, u8 r2)

--- a/src/code_805D8C8.c
+++ b/src/code_805D8C8.c
@@ -43,13 +43,12 @@ OpenedFile *sub_80687D0(s16 species)
 // https://decomp.me/scratch/CI98Y
 //
 #ifdef NONMATCHING
-static void sub_80687EC(s32 _id)
+static void sub_80687EC(s32 id)
 {
     u8 name [12];
-    s16 id = _id;
 
     if (gDungeon->sprites[id] == NULL) {
-        sprintf(name, gUnknown_8106EA0);
+        sprintf(name, gUnknown_8106EA0, id);
         gDungeon->sprites[id] = OpenFileAndGetFileDataPtr(name, &gMonsterFileArchive);
     }
 }

--- a/src/code_805D8C8.c
+++ b/src/code_805D8C8.c
@@ -39,60 +39,16 @@ OpenedFile *sub_80687D0(s16 species)
     return gDungeon->sprites[species32];
 }
 
-// 85.94 matching (Seth)
-// https://decomp.me/scratch/CI98Y
-//
-#ifdef NONMATCHING
-static void sub_80687EC(s32 id)
+static void sub_80687EC(s32 _id)
 {
     u8 name [12];
+    s32 id = (s16)_id;
 
     if (gDungeon->sprites[id] == NULL) {
         sprintf(name, gUnknown_8106EA0, id);
         gDungeon->sprites[id] = OpenFileAndGetFileDataPtr(name, &gMonsterFileArchive);
     }
 }
-#else
-NAKED
-static void sub_80687EC(s32 _id)
-{
-    asm_unified(
-    "\tpush {r4,r5,lr}\n"
-    "\tsub sp, 0xC\n"
-    "\tlsls r0, 16\n"
-    "\tasrs r2, r0, 16\n"
-    "\tldr r5, _08068828\n"
-    "\tldr r0, [r5]\n"
-    "\tlsls r4, r2, 2\n"
-    "\tldr r1, _0806882C\n"
-    "\tadds r0, r1\n"
-    "\tadds r0, r4\n"
-    "\tldr r0, [r0]\n"
-    "\tcmp r0, 0\n"
-    "\tbne _08068820\n"
-    "\tldr r1, _08068830\n"
-    "\tmov r0, sp\n"
-    "\tbl sprintf\n"
-    "\tldr r1, _08068834\n"
-    "\tmov r0, sp\n"
-    "\tbl OpenFileAndGetFileDataPtr\n"
-    "\tldr r1, [r5]\n"
-    "\tldr r2, _0806882C\n"
-    "\tadds r1, r2\n"
-    "\tadds r1, r4\n"
-    "\tstr r0, [r1]\n"
-"_08068820:\n"
-    "\tadd sp, 0xC\n"
-    "\tpop {r4,r5}\n"
-    "\tpop {r0}\n"
-    "\tbx r0\n"
-    "\t.align 2, 0\n"
-"_08068828: .4byte gDungeon\n"
-"_0806882C: .4byte 0x00017b44\n"
-"_08068830: .4byte gUnknown_8106EA0\n"
-"_08068834: .4byte gMonsterFileArchive");
-}
-#endif
 
 void sub_8068838(s16 id, bool32 a1)
 {

--- a/src/code_8066D04.c
+++ b/src/code_8066D04.c
@@ -50,7 +50,7 @@ void HandleSetItemAction(Entity *param_1, bool8 param_2)
   Item *item;
   Item *itemPtr;
   s32 index;
-  
+
   item = sub_8044D90(param_1,0,0xfe);
   for(index = 0; index < INVENTORY_SIZE; index++)
   {
@@ -92,7 +92,7 @@ void HandleUnsetItemAction(Entity *entity,bool8 enableMessage)
 {
   Item *item;
   int index;
-  
+
   for(index = 0; index < INVENTORY_SIZE; index++)
   {
     item = &gTeamInventoryRef->teamItems[index];
@@ -123,7 +123,7 @@ void HandleGiveItemAction(Entity *param_1)
   Item item1;
   Item item2;
   Item item3;
-  
+
   entity = sub_8044DA4(param_1,1);
   info1 = param_1->info;
   info2 = entity->info;
@@ -133,7 +133,7 @@ void HandleGiveItemAction(Entity *param_1)
       bVar3 = TRUE;
   else
       bVar3 = FALSE;
-    
+
   if ((!bVar3) && ((item->flags & (ITEM_FLAG_STICKY | ITEM_FLAG_SET)) == (ITEM_FLAG_STICKY | ITEM_FLAG_SET))) {
     sub_8045BF8(gUnknown_202DEA8,item);
     SendMessage(param_1,*gUnknown_80F8C44);
@@ -198,7 +198,7 @@ void HandleTakeItemAction(Entity *param_1)
   EntityInfo *info2;
   Item *heldItem;
   Item item;
-  
+
   entity = sub_8044DA4(param_1,0);
   info = entity->info;
   info2 = entity->info;
@@ -244,7 +244,7 @@ void sub_8066BD4(Entity *param_1)
   Item *item;
   Item *heldItem;
   Item temp;
-  
+
   entity = sub_8044DA4(param_1,0);
   info = entity->info;
   info2 = entity->info;
@@ -284,7 +284,7 @@ void sub_8066BD4(Entity *param_1)
 void HandleUseItemAction(Entity *param_1)
 {
   Entity *entity;
-  
+
   entity = sub_8044DA4(param_1,0);
   entity->info->useHeldItem = TRUE;
 }

--- a/src/code_8069E0C.c
+++ b/src/code_8069E0C.c
@@ -225,7 +225,7 @@ void sub_806A120(Entity * pokemon, Entity * target, Move* move)
 }
 
 void sub_806A1B0(Entity *pokemon)
-{ 
+{
   if ((EntityExists(pokemon)) && (HasAbility(pokemon, ABILITY_TRUANT))) {
     PausedStatusTarget(pokemon,pokemon,0,1,0);
   }
@@ -235,7 +235,7 @@ void sub_806A1E8(Entity *pokemon)
 {
   bool8 bVar3;
   EntityInfo *entityInfo;
-  
+
   bVar3 = FALSE;
   if (EntityExists(pokemon)) {
     if (GetEntityType(pokemon) == ENTITY_MONSTER) {
@@ -255,7 +255,7 @@ void sub_806A240(Entity *pokemon, Entity *target)
 {
   bool8 isNotTeamMember;
   EntityInfo *entityInfo;
-  
+
   isNotTeamMember = FALSE;
   if (EntityExists(pokemon)){
     if (GetEntityType(pokemon) == ENTITY_MONSTER) {

--- a/src/code_808333C.c
+++ b/src/code_808333C.c
@@ -23,7 +23,7 @@ bool8 sub_8083568(s32 inX, s32 inY, u8 index) {
 
     x = inX - gDungeon->cameraPixelPos.x;
     y = inY - gDungeon->cameraPixelPos.y;
-    
+
     if (x >= -16 && y >= -16 && x <= 255 && y <= 175)
     {
         struct unkStruct_202ED28 *ptr = gUnknown_202ED28;
@@ -50,7 +50,7 @@ bool8 sub_8083568(s32 inX, s32 inY, u8 index) {
         tmp2 |= tmp;
         sp->unk6 = tmp2;
 
-        
+
         AddSprite(sp, 0, NULL, NULL);
         return TRUE;
     }

--- a/src/code_80869E4.c
+++ b/src/code_80869E4.c
@@ -37,6 +37,7 @@ extern void sub_8086A54(Entity *);
 extern void sub_8086A3C(Entity *);
 extern void PlaySoundEffect(u32);
 extern void sub_80861F8(u32, Entity *, u32);
+extern u32 sub_8002A70(u32, s32, u8);
 
 void SpriteShockEffect(Entity *entity)
 {
@@ -480,7 +481,6 @@ void SpriteLookAroundEffect(Entity *entity)
 void sub_80869E4(Entity *a0, s32 a1, u8 a2, s8 a3)
 {
     u32 r4;
-    s8 *r5;
     s32 tmp;
     struct EntityInfo* info;
 

--- a/src/code_8094148.c
+++ b/src/code_8094148.c
@@ -1,13 +1,13 @@
 #include "global.h"
 
-s32 *sub_8094268(s32 *param_1, s32 param_2, s32 param_3) 
+s32 *sub_8094268(s32 *param_1, s32 param_2, s32 param_3)
 {
     s32 x;
     s32 y;
     u16 z;
 
     y = param_2;
-    
+
     x = ((y >> 0x10) + (param_3 >> 0x10)) << 0x10;
     y = (y & 0x0000ffff) | x;
     z = y + param_3;

--- a/src/code_8094F88.c
+++ b/src/code_8094F88.c
@@ -59,7 +59,7 @@ void sub_8095118(void)
 {
   s32 index;
   unkStruct_203B480 *unused;
-  
+
   MemoryFill8((u8*)gUnknown_203B480,0, 0x20 * sizeof(unkStruct_203B480));
   MemoryFill8((u8*)gUnknown_203B484,0, sizeof(unkStruct_203B484));
   for(index = 0; index < 0x20; index++){
@@ -89,7 +89,7 @@ void nullsub_207(void)
 s32 FindOpenMailSlot(void)
 {
   s32 index;
-  
+
   for(index = 2; index < 0x20; index++){
     if(gUnknown_203B480[index].mailType == WONDER_MAIL_TYPE_NONE)
         return index;
@@ -149,7 +149,7 @@ void sub_8095274(u32 param_1)
 {
   s32 iVar2;
   s32 iVar3;
-  
+
   gUnknown_203B48C->unk4[gUnknown_203B48C->unk0] = param_1;
   iVar2 = gUnknown_203B48C->unk0;
   iVar3 = 0;
@@ -162,7 +162,7 @@ void sub_8095274(u32 param_1)
 bool8 sub_8095298(s32 param_1)
 {
   s32 index;
-  
+
   for(index = 0; index < 0x20; index++)
   {
     if(gUnknown_203B48C->unk4[index] == param_1) return TRUE;
@@ -173,7 +173,7 @@ bool8 sub_8095298(s32 param_1)
 void sub_80952C4(void)
 {
   s32 index;
-  
+
   gUnknown_203B48C->unk0 = 0;
   for(index = 0; index < 0x20; index++)
   {
@@ -185,9 +185,9 @@ bool8 HasMail(u8 mailType, u32 param_2)
 {
   unkStruct_203B480 *ptr;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0]; index < 0x20; ptr++, index++)
-  {  
+  {
     if ((ptr->mailType == mailType) && (ptr->unk10.unk10 == param_2)) return TRUE;
   }
   return FALSE;
@@ -198,9 +198,9 @@ s32 CountMailType(u8 mailType)
   unkStruct_203B480 *ptr;
   s32 total = 0;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0]; index < 0x20; ptr++, index++)
-  {  
+  {
     if (ptr->mailType == mailType) total++;
   }
   return total;
@@ -211,9 +211,9 @@ u32 CountAllMail(void)
   unkStruct_203B480 *ptr;
   u32 total = 0;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0]; index < 0x20; ptr++, index++)
-  {  
+  {
     if (ptr->mailType != 0) total++;
   }
   return total;
@@ -224,9 +224,9 @@ s32 sub_8095374(void)
   unkStruct_203B480 *ptr;
   s32 retvar = -1;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0]; index < 0x20; ptr++, index++)
-  {  
+  {
     if (ptr->mailType == 1) retvar = index;
   }
   return retvar;
@@ -237,9 +237,9 @@ s32 GetMailIndex(u8 mailType, u32 param_2)
 {
   unkStruct_203B480 *ptr;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0]; index < 0x20; ptr++, index++)
-  {  
+  {
     if ((ptr->mailType == mailType) && (ptr->unk10.unk10 == param_2)) return index;
   }
   return -1;
@@ -250,9 +250,9 @@ s32 GetFirstIndexofMailType(u8 mailType)
 {
   unkStruct_203B480 *ptr;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0]; index < 0x20; ptr++, index++)
-  {  
+  {
     if (ptr->mailType == mailType) return index;
   }
   return -1;
@@ -262,9 +262,9 @@ s32 sub_8095400(u32 param_1)
 {
   u32 *ptr;
   s32 index;
-  
+
   for(index = 0, ptr = &gUnknown_203B480[0].unk10.unk10; index < 0x20; ptr += 0xC, index++)
-  {  
+  {
     if (*ptr == param_1) return index;
   }
   return -1;
@@ -281,7 +281,7 @@ void sub_809542C(WonderMailSub *param_1)
 #endif
 
   u8 buffer [20];
-  
+
   gUnknown_203B480->mailType = 1;
   preload = gUnknown_203B480;
   seed = param_1->seed;
@@ -301,7 +301,7 @@ void sub_8095494(WonderMailSub *param_1, u8 index)
   u32 seed;
   DungeonLocation dungeon;
   unkStruct_203B480 *mail;
-  
+
   mail = gUnknown_203B480;
   mail += index;
 

--- a/src/code_8097504.c
+++ b/src/code_8097504.c
@@ -86,7 +86,7 @@ bool32 IsMazeCompleted(s16 mazeIndex)
 }
 
 void sub_80975A8(s16 param_1,u8 param_2)
-{ 
+{
     u16 param_1_u16 = param_1;
     sub_800199C(0,0x2e,param_1_u16,param_2);
 }

--- a/src/credits1.c
+++ b/src/credits1.c
@@ -76,7 +76,7 @@ bool8 DrawCredits(s32 creditsCategoryIndex, s32 param_2)
         xxx_call_draw_string(x, y, srcText, 0, 0);
         cred++;
     }
-    
+
     sub_80073E0(0);
     SelectCharmap(0);
     do {

--- a/src/dungeon_movement.c
+++ b/src/dungeon_movement.c
@@ -290,7 +290,7 @@ s32 CalcSpeedStage(Entity *pokemon)
   s32 index;
   s32 speed;
   EntityInfo * entityInfo;
-  
+
   entityInfo = pokemon->info;
   speed = 0;
 

--- a/src/dungeon_music.c
+++ b/src/dungeon_music.c
@@ -128,7 +128,7 @@ bool8 sub_8083C88(u8 param_1)
 
   temp = &gDungeon->unk1CE98;
 
-  if ((!HasCheckpoint(gDungeon->dungeonLocation.id) && 
+  if ((!HasCheckpoint(gDungeon->dungeonLocation.id) &&
       ((gDungeon->unk65C != 0) || (param_1 != 0))) ||
      (temp->moveID != 0x227)) {
     return TRUE;
@@ -270,7 +270,7 @@ void StopDungeonBGM(void)
 
 void UpdateDungeonMusic(void)
 {
-#ifndef NONMATCHING    
+#ifndef NONMATCHING
   register s32 currSongIndex asm("r1");
   register u16 *bossSongIndex asm("r3");
 #else
@@ -279,7 +279,7 @@ void UpdateDungeonMusic(void)
 #endif
   s32 newSongIndex;
   DungeonMusicPlayer *musPlayer;
-  
+
   musPlayer = &gDungeon->musPlayer;
 
   bossSongIndex = &gDungeon->bossSongIndex;

--- a/src/dungeon_pokemon_attributes.c
+++ b/src/dungeon_pokemon_attributes.c
@@ -263,7 +263,7 @@ bool8 sub_8071A8C(Entity *pokemon)
 }
 
 bool8 SetVisualFlags(EntityInfo *entityInfo, u16 newFlag, bool8 param_3)
-{ 
+{
   if ((entityInfo->visualFlags & newFlag)) {
     entityInfo->previousVisualFlags = newFlag | entityInfo->previousVisualFlags;
   }

--- a/src/friend_area_action_menu.c
+++ b/src/friend_area_action_menu.c
@@ -289,7 +289,7 @@ void CreateFriendActionMenu(void)
       sUnknown_203B2BC->unk16C[loopMax] = 1;
   }
   loopMax += 1;
-    
+
   sUnknown_203B2BC->menuItems[loopMax].text = sTake;
   sUnknown_203B2BC->menuItems[loopMax].menuAction = FRIEND_AREA_ACTION_MENU_ACTION_TAKE;
   if(GetNumberOfFilledInventorySlots() >= INVENTORY_SIZE || sUnknown_203B2BC->item2.id == ITEM_NOTHING)
@@ -317,7 +317,7 @@ void CreateFriendActionMenu(void)
               return;
       }
   }
-    
+
   for(index = 0; index < loopMax; index++)
   {
       if(sUnknown_203B2BC->unk16C[index] == 0)
@@ -355,7 +355,7 @@ void sub_80276A8(void)
               return;
       }
   }
-    
+
   for(index = 0; index < loopMax; index++)
   {
       if(sUnknown_203B2BC->unk16C[index] == 0)
@@ -369,7 +369,7 @@ void sub_80276A8(void)
 void sub_8027794(void)
 {
   s32 loopMax = 0;
-  
+
   MemoryFill16(sUnknown_203B2BC->unk16C,0,sizeof(sUnknown_203B2BC->unk16C));
   sUnknown_203B2BC->menuItems[loopMax].text = gCommonYes[0];
   sUnknown_203B2BC->menuItems[loopMax].menuAction = FRIEND_AREA_ACTION_MENU_ACTION_YES;

--- a/src/friend_rescue.c
+++ b/src/friend_rescue.c
@@ -687,7 +687,7 @@ void sub_8032828(void)
     PokemonStruct1 *pokeStruct1;
     PokemonStruct1 *pokeStruct2;
     char *monName;
-    
+
     switch (gUnknown_203B33C->state) {
         case 0x0:
             if (CountMailType(WONDER_MAIL_TYPE_SOS) == 0 && CountMailType(WONDER_MAIL_TYPE_THANK_YOU) == 0) {
@@ -967,7 +967,7 @@ void sub_8032828(void)
                         gUnknown_203B33C->status = sub_8037D64(gUnknown_203B33C->unk40, &gUnknown_203B33C->unkA8, &gUnknown_203B33C->unk130);
                         break;
                 }
-                
+
                 if (gUnknown_203B33C->status == 0) {
                     switch (gUnknown_203B33C->unk40) {
                         case 2:
@@ -1004,7 +1004,7 @@ void sub_8032828(void)
             sub_800641C(NULL, TRUE, TRUE);
             sub_80306A8(1, 0, NULL, 6);
             break;
-        case 0x15:            
+        case 0x15:
             sub_8014248(&gUnknown_80E2F78[0], 0, 6, &gUnknown_80E2290, NULL, 4, 0, NULL, 0x101);
             break;
         case 0xF:

--- a/src/menu_input.c
+++ b/src/menu_input.c
@@ -790,7 +790,7 @@ static void sub_801332C(s16 *a0)
 static void sub_8013470(MenuInputStruct *a0)
 {
     SpriteOAM sp = {};
-    #if NONMATCHING // SpriteOAM memes https://decomp.me/scratch/70Ieb TODO: Match like sub_8039174 with multiple vars and while(0)
+    #ifdef NONMATCHING // SpriteOAM memes https://decomp.me/scratch/70Ieb TODO: Match like sub_8039174 with multiple vars and while(0)
     SpriteOAM *ptr;
     u32 r0, r1, r5;
     #else

--- a/src/move_actions.c
+++ b/src/move_actions.c
@@ -80,8 +80,8 @@ extern u8 *gUnknown_80FD2B4[];
 extern u8 *gUnknown_80FAC74[];
 extern u8 *gUnknown_80FAC54[];
 extern u32 gUnknown_80F4F50;
-extern s16 gUnknown_80F4DB8; 
-extern s16 gUnknown_80F4DBA; 
+extern s16 gUnknown_80F4DB8;
+extern s16 gUnknown_80F4DBA;
 extern s16 gUnknown_80F55BC[];
 extern u8 *gUnknown_80FAE00[];
 extern u8 *gUnknown_80FADD8[];
@@ -370,7 +370,7 @@ bool8 sub_805768C(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 {
     bool8 flag;
 
-    flag = FALSE;  
+    flag = FALSE;
     gUnknown_202F21C++;
 
     if (sub_8055640(pokemon, target, move, gUnknown_8106A54[gUnknown_202F21C], param_4) == 0)
@@ -557,7 +557,7 @@ bool8 TormentMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param_4
   Move struggleMove;
   EntityInfo *entityInfo;
   bool8 isTormented;
-  
+
   entityInfo = target->info;
   isTormented = FALSE;
 
@@ -663,7 +663,7 @@ bool32 sub_8057CD0(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 {
   u32 weather;
   s32 flag;
-  
+
   weather = GetApparentWeather(pokemon);
   flag = sub_80556BC(pokemon,target,gUnknown_80F51E4[weather],move,
                       gUnknown_80F51EC[weather],param_4);
@@ -792,7 +792,7 @@ bool8 sub_8057E6C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   EntityInfo *entityInfo;
   bool8 flag;
-  
+
   flag = FALSE;
   entityInfo = pokemon->info;
   SendThawedMessage(pokemon,target);
@@ -808,7 +808,7 @@ bool8 sub_8057E6C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8057ED0(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -823,7 +823,7 @@ bool8 sub_8057ED0(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8057F24(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 {
   EntityInfo *entityInfo;
-  
+
   entityInfo = pokemon->info;
   entityInfo->HP = 1;
   ChangeAttackMultiplierTarget(pokemon,target,gUnknown_8106A4C,0x40,TRUE);
@@ -835,7 +835,7 @@ bool8 sub_8057F24(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 bool8 sub_8057F7C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -857,7 +857,7 @@ bool8 sub_8057FCC(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 bool8 sub_8057FF4(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 {
   u8 flashFireStatus;
-  
+
   flashFireStatus = GetFlashFireStatus(target);
   if (flashFireStatus != FLASH_FIRE_STATUS_NONE) {
     if (target->info->unk152 == 0) {
@@ -887,7 +887,7 @@ bool8 sub_805805C(Entity * pokemon,Entity * target,Move * move,s32 param_4)
   s32 IQ;
 
   entityInfo = pokemon->info;
-  
+
 
   r6 = 1;
   index = 0;
@@ -911,7 +911,7 @@ bool8 GrudgeMoveAction(Entity *pokemon, Entity * target, Move *move, s32 param_4
 {
   EntityInfo *entityInfo;
   bool8 hasGrudge;
-  
+
   hasGrudge = FALSE;
   entityInfo = target->info;
   SetMessageArgument(gUnknown_202DFE8,target,0);
@@ -935,7 +935,7 @@ bool8 CounterMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param_4
 bool8 sub_805816C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   SendThawedMessage(pokemon, target);
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
@@ -951,7 +951,7 @@ bool8 sub_805816C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_80581D0(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   SendThawedMessage(pokemon, target);
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
@@ -1011,7 +1011,7 @@ bool8 sub_80582D4(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 RazorWindMoveAction(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 {
   bool8 flag;
-  
+
   if (MoveMatchesChargingStatus(pokemon,move)) {
     flag = sub_8055640(pokemon,target,move,gUnknown_80F4F50,param_4) ? TRUE : FALSE;
     sub_8079764(pokemon);
@@ -1026,14 +1026,14 @@ bool8 RazorWindMoveAction(Entity * pokemon, Entity * target, Move * move, u32 pa
 bool8 BideMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
    SetChargeStatusTarget(pokemon, target, STATUS_BIDE, move, *gUnknown_80FAC74);
-   return TRUE; 
+   return TRUE;
 }
 
 bool8 sub_805836C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   s32 iVar2;
   bool8 local_18;
-  
+
   local_18 = FALSE;
   iVar2 = pokemon->info->unkA0 * 2;
   if (999 < iVar2) {
@@ -1048,7 +1048,7 @@ bool8 sub_805836C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_80583D8(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1063,7 +1063,7 @@ bool8 sub_80583D8(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8058430(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1078,7 +1078,7 @@ bool8 sub_8058430(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8058478(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1126,7 +1126,7 @@ bool8 sub_8058548(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8058580(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1141,7 +1141,7 @@ bool8 sub_8058580(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 BrickBreakMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if ((target->info->protection.protectionStatus == STATUS_REFLECT) || (target->info->protection.protectionStatus == STATUS_LIGHT_SCREEN)) {
     sub_80522F4(pokemon,target,*gUnknown_80FD104); // The barrier was shattered
@@ -1156,7 +1156,7 @@ bool8 BrickBreakMoveAction(Entity *pokemon, Entity *target, Move *move, u32 para
 bool8 sub_8058638(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1171,7 +1171,7 @@ bool8 sub_8058638(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 FocusPunchMoveAction(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 {
   bool8 flag;
-  
+
   if (MoveMatchesChargingStatus(pokemon,move)) {
     flag = sub_8055640(pokemon,target,move,gUnknown_80F4F54,param_4) ? TRUE : FALSE;
     sub_8079764(pokemon);
@@ -1190,7 +1190,7 @@ bool8 sub_80586DC(Entity * pokemon, Entity * target, Move * move, u32 param_4)
   s32 newHP;
   bool8 flag;
   EntityInfo *entityInfo;
-  
+
   hasLiquidOoze = HasAbility(target, ABILITY_LIQUID_OOZE);
   uVar3 = sub_8055640(pokemon,target,move,0x100,param_4);
   flag = uVar3 != 0 ? TRUE : FALSE;
@@ -1228,7 +1228,7 @@ bool8 sub_8058770(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 #else
   EntityInfo *entityInfo;
 #endif
- 
+
   entityInfo = pokemon->info;
   r2 = entityInfo->maxHPStat;
   r0 = r2;
@@ -1258,7 +1258,7 @@ bool8 sub_8058770(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 bool8 sub_80587E8(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 {
   bool8 flag;
-  
+
   if (target->info->nonVolatile.nonVolatileStatus == STATUS_PARALYSIS) {
     flag = sub_8055640(pokemon,target,move,0x80 << 2,param_4) ? TRUE : FALSE;
     SendNonVolatileEndMessage(pokemon, target);
@@ -1301,7 +1301,7 @@ bool8 sub_80588B8(Entity *pokemon, Entity *target, Move *move, u32 param_4)
     if(sub_8055640(pokemon, target, move, 0x80 << 1, param_4) != 0)
     {
         flag = TRUE;
-        if(sub_8057308(pokemon, 0)) 
+        if(sub_8057308(pokemon, 0))
         {
             gUnknown_202F219 = 1;
         }
@@ -1313,7 +1313,7 @@ bool8 sub_80588F4(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
     bool8 flag;
     EntityInfo *entityInfo = target->info;
-    
+
     flag = sub_8055640(pokemon, target, move, GetWeight(entityInfo->apparentID), param_4) != 0 ? TRUE: FALSE;
     return flag;
 }
@@ -1328,7 +1328,7 @@ bool8 sub_8058930(Entity *pokemon, Entity *target, Move *move, u32 param_4)
     if(sub_8055640(pokemon, target, move, 0x80 << 1, param_4) != 0)
     {
         flag = TRUE;
-        if(sub_8057308(pokemon, gUnknown_80F4DD6)) 
+        if(sub_8057308(pokemon, gUnknown_80F4DD6))
         {
             entityInfo = pokemon->info;
             RaiseMovementSpeedTarget(pokemon, pokemon, 0, TRUE);
@@ -1365,7 +1365,7 @@ bool8 sub_8058A18(Entity *pokemon, Entity *target, Move *move, u32 param_4)
     if(sub_8055640(pokemon, target, move, 0x80 << 1, param_4) != 0)
     {
         flag = TRUE;
-        if(sub_8057308(pokemon, 0)) 
+        if(sub_8057308(pokemon, 0))
         {
             gUnknown_202F21A = 1;
         }
@@ -1409,7 +1409,7 @@ bool8 SkyAttackMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param
 bool8 sub_8058B3C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1425,7 +1425,7 @@ bool8 sub_8058B84(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
   EntityInfo *entityInfo;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1455,7 +1455,7 @@ bool8 sub_8058BF0(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8058C00(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1471,7 +1471,7 @@ bool8 sub_8058C48(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   s32 rand;
   bool8 flag;
-  
+
   rand = DungeonRandRange(128, 384); // 0x80 - 0x180
   rand = (rand * pokemon->info->level) / 256;
   if (rand < 0) {
@@ -1487,7 +1487,7 @@ bool8 sub_8058C48(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8058C98(Entity *pokemon, Entity *target, Move *move, u32 param_4, u32 param_5)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_5) != 0) {
     flag = TRUE;
@@ -1505,7 +1505,7 @@ bool8 sub_8058CEC(Entity *pokemon, Entity *target, Move *move, u32 param_4)
     if(sub_8055640(pokemon, target, move, 0x80 << 1, param_4) != 0)
     {
         flag = TRUE;
-        if(sub_8057308(pokemon, 0)) 
+        if(sub_8057308(pokemon, 0))
         {
             LowerAttackStageTarget(pokemon, pokemon, gUnknown_8106A50, 2, 0, FALSE);
         }
@@ -1533,7 +1533,7 @@ bool8 sub_8058D44(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 #else
   EntityInfo *entityInfo;
 #endif
- 
+
   entityInfo = pokemon->info;
   r2 = entityInfo->maxHPStat;
   r0 = r2;
@@ -1566,7 +1566,7 @@ bool8 PsychUpMoveAction(Entity * pokemon, Entity * target, Move * move, u32 para
   s32 index;
   EntityInfo *iVar3;
   EntityInfo *iVar4;
-  
+
   iVar4 = pokemon->info;
   iVar3 = target->info;
   nullsub_92(target);
@@ -1592,7 +1592,7 @@ bool8 sub_8058E5C(Entity *pokemon, Entity *target, Move *move, s32 param_4)
   int iVar2;
   int iVar3;
   bool8 flag;
-  
+
   flag = FALSE;
   if ((sub_8055640(pokemon, target, move, 0x80 << 1, param_4) != 0) && (EntityExists(pokemon))) {
     iVar2 = pokemon->info->maxHPStat;
@@ -1622,7 +1622,7 @@ bool32 sub_8058F04(Entity *pokemon, Entity *target, Move *move, s32 param_4)
   bool32 flag;
   EntityInfo *entityInfo;
   s32 iVar3;
-  
+
   entityInfo = target->info;
   iVar3 = 1;
   gDungeon->unk18200 = 0xc;
@@ -1642,7 +1642,7 @@ bool8 NaturePowerMoveAction(Entity *pokemon, Entity *target, Move *move, s32 par
   bool8 flag;
   s32 tileset;
   Move natureMove;
-  
+
   tileset = gDungeon->tileset;
   if (tileset < 0) {
     tileset = 0;
@@ -1658,7 +1658,7 @@ bool8 NaturePowerMoveAction(Entity *pokemon, Entity *target, Move *move, s32 par
 bool8 sub_8058FBC(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1691,7 +1691,7 @@ bool8 ChargeMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059080(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1714,7 +1714,7 @@ bool8 sub_80590D4(Entity *pokemon, Entity *target, Move *move, s32 param_4)
   u8 moveType;
   bool8 uVar5;
   bool8 flag;
-  
+
   flag = FALSE;
   moveType = GetMoveType(move);
 
@@ -1736,7 +1736,7 @@ bool8 sub_80590D4(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 bool8 sub_8059190(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -1761,7 +1761,7 @@ bool8 sub_80591E4(Entity *pokemon, Entity *target, Move *move, s32 param_4)
   s32 iVar4;
   bool8 flag;
   EntityInfo *entityInfo;
-  
+
   flag = FALSE;
   hasLiquidOoze = HasAbility(target, ABILITY_LIQUID_OOZE);
   iVar3 = sub_8055640(pokemon,target,move,0x100,param_4);
@@ -1798,7 +1798,7 @@ bool8 SkillSwapMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param
   u8 *puVar6;
   EntityInfo * targetEntityInfo;
   EntityInfo * pokeEntityData;
-  
+
   pokeEntityData = pokemon->info;
   targetEntityInfo = target->info;
   if ((HasAbility(target, ABILITY_WONDER_GUARD)) || (HasAbility(pokemon, ABILITY_WONDER_GUARD))) {
@@ -1827,7 +1827,7 @@ bool8 SkillSwapMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param
   return flag;
 }
 
-// https://decomp.me/scratch/Ul8x5 
+// https://decomp.me/scratch/Ul8x5
 #ifdef NONMATCHING
 bool32 SketchMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param_4)
 {
@@ -1838,7 +1838,7 @@ bool32 SketchMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param_4
   register bool32 flag asm("sl");
   struct Move *move1;
   s32 other_flag = 0;
-    
+
   flag = 0;
   pokeInfo = pokemon->info;
   targetInfo = target->info;
@@ -1850,7 +1850,7 @@ bool32 SketchMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param_4
       if ((((move1->moveFlags & MOVE_FLAG_EXISTS))) && ((targetInfo->moves[moveIndex].moveFlags & 0x10))) {
             moveID = targetInfo->moves[moveIndex].id;
             goto _moveIDcheck;
-      }    
+      }
   }
 
   if(other_flag == 0)
@@ -1866,7 +1866,7 @@ _moveIDcheck:
   else {
       InitPokemonMove(move, moveID);
       sub_80928C0(gUnknown_202DE58, move, 0);
-      move->moveFlags2 |= MOVE_FLAG2_UNK4;  
+      move->moveFlags2 |= MOVE_FLAG2_UNK4;
       move->moveFlags2 |= MOVE_FLAG_REPLACE;
       sub_80522F4(pokemon, target, *gUnknown_80FE38C);
       if (pokeInfo->unkFB == 0) {
@@ -2003,7 +2003,7 @@ bool32 SketchMoveAction(Entity *pokemon, Entity *target, Move *move, s32 param_4
 bool8 sub_8059424(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2019,7 +2019,7 @@ bool8 sub_805946C(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
   s32 HP;
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon, target, move, 0x100, param_4) != 0) {
     flag = TRUE;
@@ -2058,7 +2058,7 @@ bool8 sub_8059528(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059540(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2079,7 +2079,7 @@ bool8 sub_8059588(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_80595A0(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2095,7 +2095,7 @@ bool8 sub_80595EC(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
   u8 moveType;
   u8 local_20;
-  
+
   local_20 = 0;
   if (sub_806F4A4(target,GetMoveType(move)) == 0) {
     sub_80522F4(pokemon,target,*gUnknown_80FEB8C);
@@ -2113,11 +2113,11 @@ bool8 SolarBeamMoveAction(Entity * pokemon,Entity * target,Move * move,u32 param
 {
   u8 weather; // weather and flag are reused in same variable
   s32 movePower;
-  
+
   weather = GetApparentWeather(pokemon);
   if ((weather == WEATHER_SUNNY) || (MoveMatchesChargingStatus(pokemon,move))) {
     movePower = gSolarBeamMovePower;
-    
+
     if (((weather == WEATHER_SANDSTORM) || (weather == WEATHER_RAIN)) || weather == WEATHER_HAIL) {
       movePower /= 2;
     }
@@ -2134,7 +2134,7 @@ bool8 SolarBeamMoveAction(Entity * pokemon,Entity * target,Move * move,u32 param
 bool8 sub_8059714(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
     u8 local_20;
-    
+
     local_20 = 0;
     sub_806F370(pokemon,target,gUnknown_80F4F7C,1,&local_20,GetMoveType(move),sub_8057600(move,param_4),0,1,0);
     local_20 = local_20 == 0;
@@ -2144,7 +2144,7 @@ bool8 sub_8059714(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 bool8 FlyMoveAction(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (MoveMatchesChargingStatus(pokemon,move)) {
       flag = sub_8055640(pokemon,target,move,gUnknown_80F4F5C,param_4) != 0 ? TRUE : FALSE;
@@ -2166,7 +2166,7 @@ bool8 sub_80597F0(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 bool8 DiveMoveAction(Entity * pokemon, Entity * target, Move * move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (IsTileGround(GetTileAtEntitySafe(pokemon))) {
     sub_80522F4(pokemon,target,*gUnknown_80FD128);
@@ -2185,7 +2185,7 @@ bool8 DiveMoveAction(Entity * pokemon, Entity * target, Move * move, u32 param_4
 bool8 sub_80598CC(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2207,7 +2207,7 @@ bool8 sub_8059928(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
   bool8 flag;
   s32 iVar2;
-  
+
   iVar2 = 1;
   flag = FALSE;
   if ((u8)(target->info->charging.chargingStatus - 7) <= 1){
@@ -2218,7 +2218,7 @@ bool8 sub_8059928(Entity * pokemon,Entity * target,Move * move,u32 param_4)
     flag = TRUE;
     if(sub_805727C(pokemon,target,gUnknown_80F4DEC) != 0) {
         CringeStatusTarget(pokemon,target,FALSE);
-    } 
+    }
   }
   return flag;
 }
@@ -2226,7 +2226,7 @@ bool8 sub_8059928(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 bool8 sub_8059988(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2260,7 +2260,7 @@ bool8 sub_8059A2C(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
     u8 local_20;
     u32 level;
-    
+
     local_20 = 0;
     level = pokemon->info->level;
     sub_806F370(pokemon,target,level,1,&local_20,GetMoveType(move),sub_8057600(move,param_4),0,1,0);
@@ -2289,7 +2289,7 @@ bool8 sub_8059AC4(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059AF8(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
   u8 local_20;
-  
+
   local_20 = 0;
   if (sub_806F4A4(target,GetMoveType(move)) == 0) {
     sub_80522F4(pokemon,target,*gUnknown_80FEB90);
@@ -2317,7 +2317,7 @@ bool8 ConversionMoveAction(Entity * pokemon,Entity * target,Move * move,u32 para
   s32 counter;
   s32 newIndex;
   Move *moveStack [MAX_MON_MOVES];
-  
+
   counter = 0;
   info = target->info;
   if (HasAbility(target, ABILITY_FORECAST)) {
@@ -2389,7 +2389,7 @@ bool8 sub_8059CF0(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059D00(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2410,7 +2410,7 @@ bool8 sub_8059D48(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059D58(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2443,7 +2443,7 @@ bool8 sub_8059DB4(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059DC4(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2458,7 +2458,7 @@ bool8 sub_8059DC4(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_8059E0C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2478,7 +2478,7 @@ bool8 sub_8059E54(Entity * pokemon,Entity * target,Move * move,u32 param_4,u8 pa
   bool8 flag;
   s32 local_30 [4];
   u8 auStack_20;
-  
+
   flag = FALSE;
   if (param_5 == 0) {
     flag = sub_8055640(pokemon,target,move,0x100,param_4) != 0 ? TRUE : FALSE;
@@ -2502,7 +2502,7 @@ bool8 sub_8059E54(Entity * pokemon,Entity * target,Move * move,u32 param_4,u8 pa
 bool8 sub_8059F38(Entity * pokemon,Entity * target,Move * move,u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (MoveMatchesChargingStatus(pokemon, move)) {
     if (sub_8055640(pokemon, target, move, gUnknown_80F4F60, param_4) != 0) {
@@ -2528,7 +2528,7 @@ bool8 sub_8059FC8(Entity * pokemon,Entity * target,Move * move,u32 param_4,u8 pa
   bool8 flag;
   s32 local_30 [4];
   u8 auStack_20;
-  
+
   flag = FALSE;
   if (param_5 == 0) {
     flag = sub_8055640(pokemon,target,move,0x200,param_4) != 0 ? TRUE : FALSE;
@@ -2611,7 +2611,7 @@ bool8 sub_805A120(Entity * pokemon,Entity * target, Move *move, u32 param_4)
         if (!(item1->flags & ITEM_FLAG_EXISTS))
             flag = TRUE;
 
-        if(!(item2->flags & ITEM_FLAG_EXISTS)) 
+        if(!(item2->flags & ITEM_FLAG_EXISTS))
             flag = TRUE;
 
         if (flag)
@@ -2661,7 +2661,7 @@ bool8 MudWaterSportMoveAction(Entity * pokemon, Entity * target, Move *move, u32
 bool8 sub_805A258(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2694,7 +2694,7 @@ bool8 SurfMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
   u32 uVar2;
-  
+
   flag = FALSE;
   if (target->info->charging.chargingStatus == STATUS_DIVING) {
       uVar2 = 0x200;
@@ -2712,7 +2712,7 @@ bool8 RolePlayMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_
 {
   EntityInfo * entityInfo;
   EntityInfo * targetEntityInfo;
-  
+
   entityInfo = pokemon->info;
   targetEntityInfo = target->info;
   if (HasAbility(target, ABILITY_WONDER_GUARD)) {
@@ -2757,7 +2757,7 @@ bool8 WishMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_805A408(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2780,7 +2780,7 @@ bool8 sub_805A464(Entity *pokemon, Entity *target, Move *move, u32 param_4)
   bool32 flag;
   Item item;
   Position pos;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon, target, move, 0x100, param_4) != 0) {
     flag = TRUE;
@@ -2814,10 +2814,10 @@ bool8 sub_805A4FC(Entity *pokemon, Entity *target, Move *move, u32 param_4)
     return TRUE;
 }
 
-bool8 SwallowMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4) 
+bool8 SwallowMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   u8 *stockpileStage;
-  
+
   stockpileStage = &target->info->stockpileStage;
   if (*stockpileStage != 0) {
     HealTargetHP(pokemon,target,gUnknown_80F51D4[*stockpileStage],0,TRUE);
@@ -2843,11 +2843,11 @@ bool8 sub_805A568(Entity * pokemon, Entity * target, Move *move, u32 param_4)
     return flag;
 }
 
-bool8 TickleMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4) 
+bool8 TickleMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   u32 stat;
   bool32 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon, target, move, 0x100, param_4) != 0) {
     flag = TRUE;
@@ -2860,11 +2860,11 @@ bool8 TickleMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
   return flag;
 }
 
-bool8 sub_805A5E8(Entity *pokemon, Entity *target, Move *move, u32 stat, u32 param_5) 
+bool8 sub_805A5E8(Entity *pokemon, Entity *target, Move *move, u32 stat, u32 param_5)
 {
   EntityInfo *entityInfo;
   bool32 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_5) != 0) {
     flag = TRUE;
@@ -2879,10 +2879,10 @@ bool8 sub_805A5E8(Entity *pokemon, Entity *target, Move *move, u32 stat, u32 par
   return flag;
 }
 
-bool8 SpitUpMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4) 
+bool8 SpitUpMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   u8 *stockpileStage;
-  
+
   stockpileStage = &pokemon->info->stockpileStage;
   if (*stockpileStage != 0) {
     sub_8055640(pokemon,target,move,*stockpileStage << 8,param_4);
@@ -2897,7 +2897,7 @@ bool8 SpitUpMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 bool8 sub_805A688(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if (sub_8055640(pokemon,target,move,0x100,param_4) != 0) {
     flag = TRUE;
@@ -2925,12 +2925,12 @@ bool8 KnockOffMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_
     targetEntityInfo2 = targetEntityInfo1;
     SetMessageArgument(gAvailablePokemonNames, pokemon, 0);
     SetMessageArgument(gAvailablePokemonNames + 0x50, target, 0);
-    if (HasAbility(target, ABILITY_STICKY_HOLD)) 
+    if (HasAbility(target, ABILITY_STICKY_HOLD))
     {
         sub_80522F4(pokemon,target,*gUnknown_80FCCE8);
         return FALSE;
     }
-    else if (HasHeldItem(target, ITEM_ALERT_SPECS)) 
+    else if (HasHeldItem(target, ITEM_ALERT_SPECS))
     {
         sub_80522F4(pokemon,target,*gUnknown_80FD57C);
         return FALSE;
@@ -2941,7 +2941,7 @@ bool8 KnockOffMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_
         itemFlag = heldItem.flags;
         flag = ITEM_FLAG_EXISTS;
         flag &= itemFlag;
-        if (flag == 0) 
+        if (flag == 0)
         {
             sub_80522F4(pokemon,target,*gUnknown_80FD18C);
             return FALSE;
@@ -2956,7 +2956,7 @@ bool8 KnockOffMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_
             pos.x = gAdjacentTileOffsets[entityInfo->action.direction].x;
             pos.y = gAdjacentTileOffsets[entityInfo->action.direction].y;
             sub_805A7D4(pokemon,target,&heldItem,&pos);
-            if (sub_80706A4(target, &target->pos) != 0) 
+            if (sub_80706A4(target, &target->pos) != 0)
             {
                 sub_807D148(pokemon, target, 0, NULL);
             }
@@ -2968,7 +2968,7 @@ bool8 KnockOffMoveAction(Entity *pokemon, Entity *target, Move *move, u32 param_
 void sub_805A7D4(Entity * pokemon, Entity * target, Item *item, Position *pos)
 {
   Entity stackEntity;
-  
+
   stackEntity.type = ENTITY_ITEM;
   stackEntity.unk24 = 0;
   stackEntity.isVisible = TRUE;
@@ -2998,7 +2998,7 @@ bool8 sub_805A85C(Entity * pokemon, Entity * target, Move *move, u32 param_4)
   s32 temp2;
   u8 check;
 
-  
+
   pos1 = target->pos;
   sub_806CDD4(target,10,8);
 
@@ -3126,7 +3126,7 @@ bool8 LightScreenMoveAction(Entity * pokemon, Entity * target, Move *move, u32 p
 bool8 SecretPowerMoveAction(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
   if ( sub_8055640(pokemon, target, move, 0x100, param_4) != 0) {
     flag = TRUE;
@@ -3169,7 +3169,7 @@ bool8 SecretPowerMoveAction(Entity * pokemon, Entity * target, Move *move, u32 p
 bool8 sub_805AC90(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 {
   bool8 flag;
-  
+
   flag = FALSE;
     if ( sub_8055640(pokemon, target, move, 0x100, param_4) != 0) {
         flag = TRUE;
@@ -3222,7 +3222,7 @@ bool8 sub_805AD54(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 #endif
   Entity **possibleTargets;
   bool8 flag;
-  
+
   flag = FALSE;
   info = pokemon->info;
   if (pokemon->info->isNotTeamMember) {
@@ -3256,7 +3256,7 @@ bool8 sub_805AD54(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 bool8 sub_805AE3C(Entity *pokemon, Entity *target, Move *move, u32 param_4)
 {
   bool8 flag;
- 
+
   SendThawedMessage(pokemon, target);
   flag = sub_8055640(pokemon,target,move,0x80 << 2,param_4) != 0 ? TRUE : FALSE;
   return flag;
@@ -3279,7 +3279,7 @@ bool8 sub_805AE74(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 bool8 sub_805AECC(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 {
     bool8 flag;
-  
+
     flag = FALSE;
     SendThawedMessage(pokemon, target);
     if ( sub_8055640(pokemon, target, move, 0x100, param_4) != 0) {
@@ -3297,7 +3297,7 @@ bool8 PresentMoveAction(Entity * pokemon, Entity * target, Move *move, u32 param
   s32 rand2;
   s32 HP;
   bool8 flag;
-#ifndef NONMATCHING    
+#ifndef NONMATCHING
   register Move *move_r6 asm("r6");
   register u32 param_4_r4 asm("r4");
 #else

--- a/src/moves.c
+++ b/src/moves.c
@@ -336,7 +336,7 @@ s32 sub_8092DB8(Move *moves, s32 index)
 
     for (i = 0; i < MAX_MON_MOVES; i++) {
         u8 flag;
-        
+
         if (--index < 0) {
             for (j = MAX_MON_MOVES - 1; j >= 0; j--) {
                 if (!(moves[j].moveFlags & MOVE_FLAG_EXISTS)) {
@@ -370,7 +370,7 @@ s32 unk_FindMoveEnabledForAIAfter8(Move *moves, s32 index)
 
     for (i = 0; i < 8; i++) {
         u8 flag;
-        
+
         if (++index == 8)
             return 0;
 
@@ -968,7 +968,7 @@ s32 sub_80935B8(Move *moves, s32 index)
 
         if (!(moves[i].moveFlags & MOVE_FLAG_EXISTS))
             break;
-        
+
         if (move->moveFlags & MOVE_FLAG_SUBSEQUENT_IN_LINK_CHAIN) {
             move->moveFlags &= ~MOVE_FLAG_SUBSEQUENT_IN_LINK_CHAIN;
             any_move_linked = TRUE;
@@ -1064,7 +1064,7 @@ static void unk_LinkedSequencesToMoves4(Move *moves, Move linkedSequences[MAX_MO
 
         for (j = 0; j < MAX_MON_MOVES; j++) {
             u8 flag;
-            
+
             if (!(linkedSequences[i][j].moveFlags & MOVE_FLAG_EXISTS))
                 continue;
 
@@ -1214,7 +1214,7 @@ static void unk_LinkedSequencesToMoves8(Move *moves, Move linkedSequences[8][8])
 
         for (j = 0; j < 8; j++) {
             u8 flag;
-            
+
             if (!(linkedSequences[i][j].moveFlags & MOVE_FLAG_EXISTS))
                 continue;
 
@@ -1272,7 +1272,7 @@ static void unk_LinkedSequencesToMoves8_v2(Move *moves, Move linkedSequences[8][
 
         for (j = 0; j < 8; j++) {
             u8 flag;
-            
+
             if (!(linkedSequences[i][j].moveFlags & MOVE_FLAG_EXISTS))
                 continue;
 

--- a/src/party_list_menu.c
+++ b/src/party_list_menu.c
@@ -189,7 +189,7 @@ static void sub_802608C(void)
             {
                 sUnknown_203B2B8->unk220[index] = sUnknown_80DD310;
             }
-            break; 
+            break;
     }
     ResetUnusedInputStruct();
     sub_800641C(sUnknown_203B2B8->unk220, TRUE, TRUE);
@@ -346,7 +346,7 @@ void sub_80264CC(void) {
         }
         loopMax += 1;
     }
-    
+
     sUnknown_203B2B8->unk16C[loopMax].text = sPartyMenuGiveGummi;
     sUnknown_203B2B8->unk16C[loopMax].menuAction = 10;
     if(!HasGummiItem())
@@ -354,20 +354,20 @@ void sub_80264CC(void) {
         sUnknown_203B2B8->unk20C[loopMax] = 1;
     }
     loopMax += 1;
-    
+
     sUnknown_203B2B8->unk16C[loopMax].text = sPartyMenuGive;
     sUnknown_203B2B8->unk16C[loopMax].menuAction = 0xB;
     if(GetNumberOfFilledInventorySlots() == 0)
     {
-        sUnknown_203B2B8->unk20C[loopMax] = 1; 
+        sUnknown_203B2B8->unk20C[loopMax] = 1;
     }
     loopMax += 1;
-    
+
     sUnknown_203B2B8->unk16C[loopMax].text = sPartyMenuTake;
     sUnknown_203B2B8->unk16C[loopMax].menuAction = 0xC;
     if(GetNumberOfFilledInventorySlots() >= INVENTORY_SIZE || sUnknown_203B2B8->item2.id == ITEM_NOTHING)
     {
-        sUnknown_203B2B8->unk20C[loopMax] = 1; 
+        sUnknown_203B2B8->unk20C[loopMax] = 1;
     }
     loopMax += 1;
 
@@ -377,11 +377,11 @@ void sub_80264CC(void) {
         sUnknown_203B2B8->unk16C[loopMax].menuAction = 9;
         if(!sub_8026EB8(pokeStruct))
         {
-            sUnknown_203B2B8->unk20C[loopMax] = 1; 
+            sUnknown_203B2B8->unk20C[loopMax] = 1;
         }
         loopMax += 1;
     }
-    
+
     sUnknown_203B2B8->unk16C[loopMax].text = sPartyMenuSummary;
     sUnknown_203B2B8->unk16C[loopMax].menuAction = 4;
     loopMax += 1;
@@ -466,7 +466,7 @@ void sub_80268CC(void)
   PokemonStruct1 *pokeStruct;
   PokemonStruct1 *pokeStruct2;
   s32 choice;
-  
+
   choice = 0;
   if ((sub_8012FD8(&sUnknown_203B2B8->unk7C) == 0) && (sub_8013114(&sUnknown_203B2B8->unk7C,&choice), choice != 1)) {
     sUnknown_203B2B8->menuAction1 = choice;

--- a/src/pokemon_3.c
+++ b/src/pokemon_3.c
@@ -304,19 +304,19 @@ void sub_808E9EC(PokemonStruct1 *r0, struct unkStruct_808E9EC *r1)
     u32 reg1_8;
     s16 reg1;
 
-    pokeAtt = r0->pokeAtt;
+    pokeAtt = r0->offense.att[0];
 
     r1->unk0 = pokeAtt;
-    r1->unk4 = r0->pokeSPAtt;
-    r1->unk8 = r0->pokeDef;
-    r1->unkC = r0->pokeSPDef;
+    r1->unk4 = r0->offense.att[1];
+    r1->unk8 = r0->offense.def[0];
+    r1->unkC = r0->offense.def[1];
     r1->unk10 = 0;
     r1->unk11 = 0;
     r1->unk12 = 0;
     r1->unk13 = 0;
-    if(r0->unk28 != 0)
+    if(r0->heldItem.id != 0)
     {
-        r4 = r0->unk28;
+        r4 = r0->heldItem.id;
         if(r4 == 0x13)
         {
             r1->unk10 = gUnknown_810AC60;
@@ -980,7 +980,7 @@ void sub_808F468(PokemonStruct1 *param_1, EvolveStatus *evolveStatus, u8 param_3
                         evolFlag = TRUE;
                     }
                 }
-                else 
+                else
                 {
                     if (FindItemInInventory(evolveConditions.evolutionRequirements.mainRequirement) < 0) {
                         evolveStatus->evolutionConditionStatus |= defaultReason;
@@ -1028,7 +1028,7 @@ void sub_808F468(PokemonStruct1 *param_1, EvolveStatus *evolveStatus, u8 param_3
                 else {
                     if (-1 < FindItemInInventory(ITEM_SUN_RIBBON)) goto _0808F6CA;
                     evolveStatus->evolutionConditionStatus |= defaultReason;
-                    continue;                
+                    continue;
                 }
             }
             else if (evolveConditions.evolutionRequirements.additionalRequirement == 9) {
@@ -1057,7 +1057,7 @@ void sub_808F468(PokemonStruct1 *param_1, EvolveStatus *evolveStatus, u8 param_3
             }
             else if (evolveConditions.evolutionRequirements.additionalRequirement == 10) {
                 if (param_3 != 0) {
-                    if ((evolveStatus->evoItem1 == ITEM_BEAUTY_SCARF) || (evolveStatus->evoItem2 == ITEM_BEAUTY_SCARF)) goto _0808F6CA; 
+                    if ((evolveStatus->evoItem1 == ITEM_BEAUTY_SCARF) || (evolveStatus->evoItem2 == ITEM_BEAUTY_SCARF)) goto _0808F6CA;
                     else continue;
                 }
                 else

--- a/src/pokemon_mid.c
+++ b/src/pokemon_mid.c
@@ -76,7 +76,7 @@ s32 sub_808D654(s32 *ptr) {
 }
 
 // 80 (97.58 % matching) - Seth
-// https://decomp.me/scratch/B8Ont 
+// https://decomp.me/scratch/B8Ont
 #ifdef NONMATCHING
 s32 sub_808D6A4(s32 *param_1)
 {
@@ -910,7 +910,7 @@ s32 GetEvolutionSequence(PokemonStruct1* pokemon, struct EvolveStage* a2)
   s32 species;
   s32 i;
 
-  a2[0].specesNum = pokemon->speciesNum;
+  a2[0].speciesNum = pokemon->speciesNum;
   a2[0].level = pokemon->level;
 
   count = 1;

--- a/src/save_menu.c
+++ b/src/save_menu.c
@@ -123,14 +123,14 @@ extern void sub_80140F8(void);
 void CreateSaveMenu(s32 currMenu)
 {
   s32 index;
-  
+
   if (sUnknown_203B364 == NULL) {
     sUnknown_203B364 = MemoryAlloc(sizeof(SaveMenuWork),8);
     MemoryFill8((u8 *)sUnknown_203B364,0,sizeof(SaveMenuWork));
   }
   for(index = 0; index < 4; index++){
     sUnknown_203B364->unk148[index] = gUnknown_80E6F20;
-  } 
+  }
   ResetUnusedInputStruct();
   sub_800641C(sUnknown_203B364->unk148, TRUE, TRUE);
 
@@ -174,7 +174,7 @@ s32 UpdateSaveMenu(void)
   switch(sUnknown_203B364->unk4)
   {
       default:
-      case 2:  
+      case 2:
         menu = MENU_NO_SCREEN_CHANGE;
         break;
       case 0:

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -155,7 +155,7 @@ void sub_8004E8C(unkStruct_2039DB0 *a0)
 
 // https://decomp.me/scratch/VYqKb
 // spriteMasks is a u16[6]
-#if NONMATCHING
+#ifdef NONMATCHING
 static void sub_8004EA8(ax_pose *a0, axdata1 *a1, UnkSpriteMem *a2, u16 *spriteMasks)
 {
     // size: 0xC

--- a/src/status_actions.c
+++ b/src/status_actions.c
@@ -171,7 +171,7 @@ bool8 sub_805AFA4(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 #else
   EntityInfo *entityInfo;
 #endif
-  
+
   SendThawedMessage(pokemon, target);
   entityInfo = pokemon->info;
   r2 = entityInfo->maxHPStat;
@@ -200,13 +200,13 @@ bool8 sub_805AFA4(Entity * pokemon, Entity * target, Move *move, u32 param_4)
 }
 
 bool8 sub_805B028(Entity * pokemon,Entity * target,Move *move)
-{ 
+{
     ParalyzeStatusTarget(pokemon,target, TRUE);
     return TRUE;
 }
 
 bool8 TransformMoveAction(Entity * pokemon, Entity * target, Move *move, s32 param_4)
-{ 
+{
   if (IsBossFight()) {
     sub_80522F4(pokemon,target,*gUnknown_80FEFF4);
     return FALSE;
@@ -219,7 +219,7 @@ bool8 TransformMoveAction(Entity * pokemon, Entity * target, Move *move, s32 par
 }
 
 bool8 sub_805B074(Entity * pokemon, Entity * target, Move *move, s32 param_4)
-{ 
+{
     bool8 flag;
 
     flag = FALSE;
@@ -233,7 +233,7 @@ bool8 sub_805B074(Entity * pokemon, Entity * target, Move *move, s32 param_4)
 }
 
 bool8 sub_805B0BC(Entity * pokemon, Entity * target)
-{ 
+{
     sub_807CD9C(pokemon, target, pokemon->info->action.direction);
     return TRUE;
 }
@@ -294,13 +294,13 @@ bool8 sub_805B17C(Entity * pokemon, Entity * target, Move *move, s32 param_4)
 }
 
 bool8 PerishSongMoveAction(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     PerishSongTarget(pokemon, target);
     return TRUE;
 }
 
 bool8 WrapMoveAction(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     WrapTarget(pokemon, target);
     return TRUE;
 }
@@ -310,11 +310,11 @@ bool8 SpikesMoveAction(Entity * pokemon, Entity * target, Move *move, s32 param_
     bool8 trapLaid;
     u8 uVar2;
     bool8 isNotTeamMember;
-    
+
     trapLaid = FALSE;
     isNotTeamMember = pokemon->info->isNotTeamMember;
     uVar2 = 1;
-    
+
     if (isNotTeamMember) {
         uVar2 = 2;
     }
@@ -336,7 +336,7 @@ bool8 sub_805B264(Entity * pokemon, Entity * target, Move *move, s32 param_4)
     s32 iVar5;
     EntityInfo *entityInfo;
 
-    entityInfo = target->info;  
+    entityInfo = target->info;
     r3 = gUnknown_202F224;
     r6 = FALSE;
 
@@ -351,19 +351,19 @@ bool8 sub_805B264(Entity * pokemon, Entity * target, Move *move, s32 param_4)
 }
 
 bool8 MagicCoatMoveAction(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     MagicCoatStatusTarget(pokemon, target);
     return TRUE;
 }
 
 bool8 ProtectMoveAction(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     ProtectStatusTarget(pokemon, target);
     return TRUE;
 }
 
 bool8 sub_805B2FC(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     RaiseDefenseStageTarget(pokemon,target,gUnknown_8106A4C,1);
     return TRUE;
 }
@@ -389,24 +389,24 @@ bool8 sub_805B324(Entity * pokemon,Entity * target,Move *move, s32 param_4)
 }
 
 bool8 DestinyBondMoveAction(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     DestinyBondStatusTarget(pokemon, target);
     return TRUE;
 }
 
 bool8 sub_805B388(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     return (sub_8055640(pokemon,target,move,0x100,param_4)) ? TRUE : FALSE;
 }
 
 bool8 MirrorCoatMoveAction(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     MirrorCoatStatusTarget(pokemon, target);
     return TRUE;
 }
 
 bool8 sub_805B3B4(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     u32 stat = gUnknown_8106A50;
     RaiseAttackStageTarget(pokemon,target,stat,1);
     RaiseDefenseStageTarget(pokemon,target,stat,1);
@@ -414,7 +414,7 @@ bool8 sub_805B3B4(Entity * pokemon,Entity * target,Move *move, s32 param_4)
 }
 
 bool8 sub_805B3E0(Entity * pokemon,Entity * target,Move *move, s32 param_4)
-{ 
+{
     sub_8055640(pokemon,target,move,0x100,param_4);
     return TRUE;
 }
@@ -528,7 +528,7 @@ bool8 sub_805B618(Entity * pokemon, Entity * target, Move *move, s32 param_4)
   u32 index;
 
   index = gUnknown_202F228;
-  
+
   InitPokemonMove(&natureMove, gUnknown_80F59C8[index].moveID);
   flag = gUnknown_80F59C8[index].move(pokemon, target, &natureMove, param_4);
   return flag;
@@ -540,7 +540,7 @@ bool8 sub_805B668(Entity * pokemon, Entity * target, Move *move, s32 param_4)
   s32 iVar3;
   s32 newHP;
   bool8 flag;
-  
+
   flag = FALSE;
   hasLiquidOoze = HasAbility(target, ABILITY_LIQUID_OOZE);
   if (IsSleeping(target)) {
@@ -584,7 +584,7 @@ bool8 RecycleMoveAction(Entity * pokemon, Entity * target, Move *move, s32 param
   s32 index;
   EntityInfo *entityInfo;
   bool8 isTMRecycled;
-  
+
   entityInfo = target->info;
   isTMRecycled = FALSE;
   if (!entityInfo->isNotTeamMember) {
@@ -635,7 +635,7 @@ bool8 sub_805B808(Entity * pokemon, Entity * target, Move *move, s32 param_4)
 }
 
 bool8 sub_805B884( Entity * pokemon, Entity * target, Move *move, s32 param_4)
-{ 
+{
     RaiseAttackStageTarget(pokemon, target, gUnknown_8106A4C, 1);
     RaiseMovementSpeedTarget(pokemon, target, 0, TRUE);
     return TRUE;
@@ -1179,8 +1179,8 @@ bool8 FillInOrbAction(Entity *pokemon,Entity *target, Move *move, s32 param_4)
     else
     {
         // Calculate the coordinates of the tile in front of the user
-        tileCoords.x = target->pos.x + gAdjacentTileOffsets[targetInfo->action.direction].x; 
-        tileCoords.y = target->pos.y + gAdjacentTileOffsets[targetInfo->action.direction].y; 
+        tileCoords.x = target->pos.x + gAdjacentTileOffsets[targetInfo->action.direction].x;
+        tileCoords.y = target->pos.y + gAdjacentTileOffsets[targetInfo->action.direction].y;
 
         sub_8042A54(&tileCoords);
         tileToFill = GetTileSafe(tileCoords.x,tileCoords.y);

--- a/src/text1.c
+++ b/src/text1.c
@@ -154,7 +154,7 @@ static void sub_8006438(const UnkTextStruct2 *a0, bool8 a1, bool8 a2, UnkTextStr
 {
     s32 i;
     u32 r9;
-    #if NONMATCHING // Simple regswap: https://decomp.me/scratch/EN6n0 99.79%
+    #ifdef NONMATCHING // Simple regswap: https://decomp.me/scratch/EN6n0 99.79%
     s16 **ptr2; // r2
     #else
     register s16 **ptr2 asm("r2");

--- a/src/text2.c
+++ b/src/text2.c
@@ -396,8 +396,8 @@ void sub_8006C44(UnkTextStruct1 *a0, s32 a1, u16 *a2, u8 a3)
     }
 }
 
-#ifdef NONMATCHING
 // Not even close but I don't feel like continuing atm https://decomp.me/scratch/F58jg
+/*
 void sub_8006E94(UnkTextStruct1 *a0, s32 a1, u32 a2, const u8 *a3, u16 *a4)
 {
     s32 bVar1;
@@ -461,7 +461,7 @@ void sub_8006E94(UnkTextStruct1 *a0, s32 a1, u32 a2, const u8 *a3, u16 *a4)
                 iVar3 = 0;
             else
                 iVar3 = a2 + a0->unk4;
-            
+
             local_24 = a4 + local_2c + iVar8 + 0x80;
             puVar10 = a4 + local_2c + iVar8 + 0x40;
             puVar6 = a4 + local_2c + iVar8;
@@ -485,7 +485,7 @@ void sub_8006E94(UnkTextStruct1 *a0, s32 a1, u32 a2, const u8 *a3, u16 *a4)
                 iVar2++;
                 if (a2 != 0)
                     a2++;
-                
+
                 if (iVar3 != 0)
                     iVar3++;
             }
@@ -580,7 +580,7 @@ void sub_8006E94(UnkTextStruct1 *a0, s32 a1, u32 a2, const u8 *a3, u16 *a4)
     (a4 + a1 * 0x20)[iVar2 + 0x40] = 0xF6D8;
     (a4 + a1 * 0x20)[iVar2 + 0x440] = 0xF2DB;
 }
-#else
+*/
 NAKED
 void sub_8006E94(UnkTextStruct1 *a0, s32 a1, u32 a2, const u8 *a3, u16 *a4)
 {
@@ -1176,7 +1176,6 @@ void sub_8006E94(UnkTextStruct1 *a0, s32 a1, u32 a2, const u8 *a3, u16 *a4)
 "_0800732C: .4byte 0x0000f27a\n"
 "_08007330: .4byte 0x0000f6d8");
 }
-#endif // NONMATCHING
 
 #ifdef NONMATCHING // https://decomp.me/scratch/zVTOf
 void sub_8007334(s32 a0)
@@ -1322,7 +1321,7 @@ UNUSED static void nullsub_156(void)
 }
 
 u32 xxx_call_draw_char(s32 x, s32 y, u32 a2, u32 color, u32 a4)
-{ 
+{
     return xxx_draw_char(gUnknown_2027370, x, y, a2, color, a4);
 }
 
@@ -1919,7 +1918,7 @@ UNUSED static void sub_80078E8(u32 a0, s32 x, s32 y, s32 a3, u32 color)
 }
 
 void sub_800792C(u32 a0, s32 x, s32 y, s32 a3, u32 color)
-{ 
+{
     sub_8007958(gUnknown_2027370, a0, x, y, a3, color);
 }
 
@@ -2052,7 +2051,7 @@ UNUSED static void nullsub_158(void)
 {
 }
 
-#if NONMATCHING // https://decomp.me/scratch/AU1bH
+#ifdef NONMATCHING // https://decomp.me/scratch/AU1bH
 void sub_8007BA8(UnkTextStruct1 *a0, u32 a1, s32 x, s32 y, s32 a4, s32 color)
 {
     s32 iVar1; // r1
@@ -2093,7 +2092,7 @@ void sub_8007BA8(UnkTextStruct1 *a0, u32 a1, s32 x, s32 y, s32 a4, s32 color)
             r6 = 0xF0000000;
             r5 = 0xE0000000;
             sp1C = 0;
-    
+
             for (iVar3 = 0; iVar3 < 8; iVar3++) {
                 if ((sp10[0] & r6) == 0)
                     sp1C |= r5;

--- a/src/unk_menu_203B360.c
+++ b/src/unk_menu_203B360.c
@@ -61,14 +61,14 @@ extern void sub_80384D0();
 void sub_80382E4(s32 currMenu)
 {
   s32 index;
-  
+
   if (sUnknown_203B360 == NULL) {
     sUnknown_203B360 = MemoryAlloc(sizeof(unkStruct_203B360), 8);
     MemoryFill8((u8 *)sUnknown_203B360, 0, sizeof(unkStruct_203B360));
   }
   for(index = 0; index < 4; index++){
     sUnknown_203B360->unk148[index] = gUnknown_80E6E7C;
-  } 
+  }
   ResetUnusedInputStruct();
   sub_800641C(sUnknown_203B360->unk148, TRUE, TRUE);
   if (currMenu == 0x25) {
@@ -98,7 +98,7 @@ u32 sub_80383D4(void)
 {
   u32 nextMenu;
   u32 menuAction;
-  
+
   menuAction = 2;
   nextMenu = MENU_NO_SCREEN_CHANGE;
 


### PR DESCRIPTION
Other than minor compile issues from struct restructuring, the main issues were:

- `sub_80687EC`: Missing argument to `sprintf` parameter caused undefined behavior.
- `sub_8006E94`: Not close to matching yet, so I commented this out rather than using `NONMATCHING`.