### PR TITLE
Fix bg control ewram vars

### DIFF
--- a/src/bg_control.c
+++ b/src/bg_control.c
@@ -7,9 +7,10 @@ EWRAM_DATA BGControlStruct gBG2Control = {0};
 EWRAM_DATA BGControlStruct gBG3Control = {0};
 static EWRAM_DATA u8 sBldAlpha_CoeffA = {0};
 static EWRAM_DATA u8 sBldAlpha_CoeffB = {0};
-EWRAM_DATA u16 gBldAlpha;
-EWRAM_DATA u16 gBldCnt;
-EWRAM_DATA bool8 gUnknown_202D7FE;
+UNUSED static EWRAM_DATA u8 sUnknownUnusedEwram[0x140] = {0};
+EWRAM_DATA u16 gBldAlpha = 0;
+EWRAM_DATA u16 gBldCnt = 0;
+EWRAM_DATA bool8 gUnknown_202D7FE = 0;
 
 void SetBldAlphaReg(s32 lowAlpha, s32 highAlpha)
 {

--- a/sym_ewram.txt
+++ b/sym_ewram.txt
@@ -127,15 +127,6 @@ gUnknown_202D2A0: /* 202D2A0 (sub_8009A1C - sub_8009BE4) */
     .space 0x3
 
     .include "src/bg_control.o"
-	.space 0x140
-
-gBldAlpha: /* 202D7FA (SetBldAlphaReg - VBlank_CB) */
-	.space 0x2
-gBldCnt: /* 202D7FC (AgbMain - VBlank_CB) */
-	.space 0x2
-gUnknown_202D7FE: /* 202D7FE (AgbMain - sub_800CD64) */
-	.space 0x2
-
     .include "src/cpu.o"
 	.space 0x4
 


### PR DESCRIPTION
Previously gBldAlpha, gBldCnt, gUnknown_202D7FE from `bg_control.c` were actually discarded.