### PR TITLE
Match and fix all(?) SpriteOAM functions

### DIFF
--- a/include/structs/sprite_oam.h
+++ b/include/structs/sprite_oam.h
@@ -114,4 +114,151 @@ typedef struct SpriteOAM
 #define SPRITEOAM_SHIFT_UNK6_4 4
 #define SPRITEOAM_MASK_UNK6_4 (SPRITEOAM_MAX_UNK6_4 << SPRITEOAM_SHIFT_UNK6_4) // ~ 0xF
 
+// These seems to work most of the time when dealing with sprite pointers. However, these DO NOT match when dealing with local variables, for example a Sprite struct on the stack.
+// These have to be macros, because static inlines WON'T match.
+
+#define SpriteSetAffine1(spritePtr, _affine1) \
+{ \
+    u32 affine1 = _affine1; \
+    affine1 &= SPRITEOAM_MAX_AFFINEMODE1; \
+    affine1 <<= SPRITEOAM_SHIFT_AFFINEMODE1; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1; \
+    (spritePtr)->attrib1 |= affine1; \
+}
+
+#define SpriteSetAffine2(spritePtr, _affine2) \
+{ \
+    u32 affine2 = _affine2; \
+    affine2 &= SPRITEOAM_MAX_AFFINEMODE2; \
+    affine2 <<= SPRITEOAM_SHIFT_AFFINEMODE2; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2; \
+    (spritePtr)->attrib1 |= affine2; \
+}
+
+#define SpriteSetObjMode(spritePtr, _objMode) \
+{ \
+    u32 objMode = _objMode; \
+    objMode &= SPRITEOAM_MAX_OBJMODE; \
+    objMode <<= SPRITEOAM_SHIFT_OBJMODE; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_OBJMODE; \
+    (spritePtr)->attrib1 |= objMode; \
+}
+
+#define SpriteSetMosaic(spritePtr, _mosaic) \
+{ \
+    u32 mosaic = _mosaic; \
+    mosaic &= SPRITEOAM_MAX_MOSAIC; \
+    mosaic <<= SPRITEOAM_SHIFT_MOSAIC; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_MOSAIC; \
+    (spritePtr)->attrib1 |= mosaic; \
+}
+
+#define SpriteSetBpp(spritePtr, _bpp) \
+{ \
+    u32 bpp = _bpp; \
+    bpp &= SPRITEOAM_MAX_BPP; \
+    bpp <<= SPRITEOAM_SHIFT_BPP; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_BPP; \
+    (spritePtr)->attrib1 |= bpp; \
+}
+
+#define SpriteSetShape(spritePtr, _shape) \
+{ \
+    u32 shape = _shape; \
+    shape &= SPRITEOAM_MAX_SHAPE; \
+    shape <<= SPRITEOAM_SHIFT_SHAPE; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_SHAPE; \
+    (spritePtr)->attrib1 |= shape; \
+}
+
+#define SpriteSetTileNum(spritePtr, _tileNum) \
+{ \
+    u32 tileNum = _tileNum; \
+    tileNum &= SPRITEOAM_MAX_TILENUM; \
+    tileNum <<= SPRITEOAM_SHIFT_TILENUM; \
+    (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_TILENUM; \
+    (spritePtr)->attrib3 |= tileNum; \
+}
+
+#define SpriteSetPriority(spritePtr, _priority) \
+{ \
+    u32 priority = _priority; \
+    priority &= SPRITEOAM_MAX_PRIORITY; \
+    priority <<= SPRITEOAM_SHIFT_PRIORITY; \
+    (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_PRIORITY; \
+    (spritePtr)->attrib3 |= priority; \
+}
+
+#define SpriteSetPalNum(spritePtr, _palNum)                \
+{                                                       \
+    u32 palNum = _palNum;                               \
+    palNum &= SPRITEOAM_MAX_PALETTENUM;                \
+    palNum <<= SPRITEOAM_SHIFT_PALETTENUM;                \
+    (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;            \
+    (spritePtr)->attrib3 |= palNum;                        \
+}
+
+#define SpriteSetMatrixNum(spritePtr, _matrixNum)                \
+{                                                       \
+    u32 matrixNum = _matrixNum;                               \
+    matrixNum &= SPRITEOAM_MAX_MATRIXNUM;                \
+    matrixNum <<= SPRITEOAM_SHIFT_MATRIXNUM;                \
+    (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;            \
+    (spritePtr)->attrib2 |= matrixNum;                        \
+}
+
+#define SpriteSetSize(spritePtr, _size)                \
+{                                                       \
+    u32 size = _size;                               \
+    size &= SPRITEOAM_MAX_SIZE;                \
+    size <<= SPRITEOAM_SHIFT_SIZE;                \
+    (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_SIZE;            \
+    (spritePtr)->attrib2 |= size;                        \
+}
+
+#define SpriteSetX(spritePtr, _x)                \
+{               \
+    u32 xSpriteVal = _x;               \
+    xSpriteVal &= SPRITEOAM_MAX_X;               \
+    xSpriteVal <<= SPRITEOAM_SHIFT_X;               \
+    (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_X;               \
+    (spritePtr)->attrib2 |= xSpriteVal;               \
+}
+
+#define SpriteSetY(spritePtr, _y) \
+{ \
+    u32 ySpriteVal = _y; \
+    ySpriteVal &= SPRITEOAM_MAX_UNK6_4; \
+    ySpriteVal <<= SPRITEOAM_SHIFT_UNK6_4; \
+    (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_4; \
+    (spritePtr)->unk6 |= ySpriteVal; \
+}
+
+#define SpriteSetUnk6_0(spritePtr, _unk6_0) \
+{ \
+    u32 unk6_0 = _unk6_0; \
+    unk6_0 &= SPRITEOAM_MAX_UNK6_0; \
+    unk6_0 <<= SPRITEOAM_SHIFT_UNK6_0; \
+    (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_0; \
+    (spritePtr)->unk6 |= unk6_0; \
+}
+
+#define SpriteSetUnk6_1(spritePtr, _unk6_1) \
+{ \
+    u32 unk6_1 = _unk6_1; \
+    unk6_1 &= SPRITEOAM_MAX_UNK6_1; \
+    unk6_1 <<= SPRITEOAM_SHIFT_UNK6_1; \
+    (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_1; \
+    (spritePtr)->unk6 |= unk6_1; \
+}
+
+#define SpriteSetUnk6_2(spritePtr, _unk6_2) \
+{ \
+    u32 unk6_2 = _unk6_2; \
+    unk6_2 &= SPRITEOAM_MAX_UNK6_2; \
+    unk6_2 <<= SPRITEOAM_SHIFT_UNK6_2; \
+    (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_2; \
+    (spritePtr)->unk6 |= unk6_2; \
+}
+
 #endif // GUARD_SPRITE_OAM_H

--- a/include/structs/sprite_oam.h
+++ b/include/structs/sprite_oam.h
@@ -225,6 +225,23 @@ typedef struct SpriteOAM
     (spritePtr)->attrib2 |= xSpriteVal;               \
 }
 
+// Hacky way of matching functions in menu_input.c AddMenuCursorSprite_, sub_801332C sub_8013470
+#define SpriteSetX_MatrixNumSize0(spritePtr, _x)                \
+{               \
+    u32 xSpriteVal = _x;               \
+    xSpriteVal &= SPRITEOAM_MAX_X;               \
+    xSpriteVal <<= SPRITEOAM_SHIFT_X;               \
+    (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_X;               \
+    (spritePtr)->attrib2 = xSpriteVal;               \
+}
+
+#define SpriteGetY(spritePtr, _y)             \
+{                                            \
+    _y = (spritePtr)->unk6;                \
+    _y >>= SPRITEOAM_SHIFT_UNK6_4;            \
+    _y &= SPRITEOAM_MAX_UNK6_4;            \
+}
+
 #define SpriteSetY(spritePtr, _y) \
 { \
     u32 ySpriteVal = _y; \
@@ -232,6 +249,14 @@ typedef struct SpriteOAM
     ySpriteVal <<= SPRITEOAM_SHIFT_UNK6_4; \
     (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_4; \
     (spritePtr)->unk6 |= ySpriteVal; \
+}
+
+#define SpriteAddY(spritePtr, addVal)         \
+{                                                \
+    u32 _yVal;                                \
+    SpriteGetY(spritePtr, _yVal);            \
+    _yVal += (addVal);                        \
+    SpriteSetY(spritePtr, _yVal);              \
 }
 
 #define SpriteSetUnk6_0(spritePtr, _unk6_0) \

--- a/include/structs/sprite_oam.h
+++ b/include/structs/sprite_oam.h
@@ -108,14 +108,22 @@ typedef struct SpriteOAM
 #define SPRITEOAM_MASK_UNK6_3 (SPRITEOAM_MAX_UNK6_3 << SPRITEOAM_SHIFT_UNK6_3) // ~ 0xFFF7
 */
 
-// Seems to be the "working" Y coord. Gets copied to attrib1's Y coord in `AddSprite()`.
-// kermalis is too lazy to rename it atm since we're still figuring things out
-#define SPRITEOAM_MAX_UNK6_4 0xFFF
-#define SPRITEOAM_SHIFT_UNK6_4 4
-#define SPRITEOAM_MASK_UNK6_4 (SPRITEOAM_MAX_UNK6_4 << SPRITEOAM_SHIFT_UNK6_4) // ~ 0xF
+// It's the "working" Y coord. Gets copied to attrib1's Y coord in `AddSprite()`.
+#define SPRITEOAM_MAX_WORKING_Y 0xFFF
+#define SPRITEOAM_SHIFT_WORKING_Y 4
+#define SPRITEOAM_MASK_WORKING_Y (SPRITEOAM_MAX_WORKING_Y << SPRITEOAM_SHIFT_WORKING_Y) // ~ 0xF
 
-// These seems to work most of the time when dealing with sprite pointers. However, these DO NOT match when dealing with local variables, for example a Sprite struct on the stack.
+// These seem to work most(all?) of the time.
 // These have to be macros, because static inlines WON'T match.
+
+#define SpriteSetOamY(spritePtr, _oamY) \
+{ \
+    u32 _oamYSpriteVal = _oamY; \
+    _oamYSpriteVal &= SPRITEOAM_MAX_Y; \
+    _oamYSpriteVal <<= SPRITEOAM_SHIFT_Y; \
+    (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_Y; \
+    (spritePtr)->attrib1 |= _oamYSpriteVal; \
+}
 
 #define SpriteSetAffine1(spritePtr, _affine1) \
 { \
@@ -247,16 +255,16 @@ typedef struct SpriteOAM
 #define SpriteGetY(spritePtr, _y)             \
 {                                            \
     _y = (spritePtr)->unk6;                \
-    _y >>= SPRITEOAM_SHIFT_UNK6_4;            \
-    _y &= SPRITEOAM_MAX_UNK6_4;            \
+    _y >>= SPRITEOAM_SHIFT_WORKING_Y;            \
+    _y &= SPRITEOAM_MAX_WORKING_Y;            \
 }
 
 #define SpriteSetY(spritePtr, _y) \
 { \
     u32 _ySpriteVal = _y; \
-    _ySpriteVal &= SPRITEOAM_MAX_UNK6_4; \
-    _ySpriteVal <<= SPRITEOAM_SHIFT_UNK6_4; \
-    (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_4; \
+    _ySpriteVal &= SPRITEOAM_MAX_WORKING_Y; \
+    _ySpriteVal <<= SPRITEOAM_SHIFT_WORKING_Y; \
+    (spritePtr)->unk6 &= ~SPRITEOAM_MASK_WORKING_Y; \
     (spritePtr)->unk6 |= _ySpriteVal; \
 }
 

--- a/include/structs/sprite_oam.h
+++ b/include/structs/sprite_oam.h
@@ -179,6 +179,13 @@ typedef struct SpriteOAM
     (spritePtr)->attrib1 |= _shapeVal; \
 }
 
+#define SpriteGetTileNum_LocalVar(spritePtr, _tileNum)             \
+{                                            \
+    _tileNum = (spritePtr)->attrib3;                \
+    _tileNum >>= SPRITEOAM_SHIFT_TILENUM;            \
+    _tileNum &= SPRITEOAM_MAX_TILENUM;            \
+}
+
 #define SpriteSetTileNum(spritePtr, _tileNum) \
 { \
     u32 _tileNumVal = _tileNum; \
@@ -186,6 +193,14 @@ typedef struct SpriteOAM
     _tileNumVal <<= SPRITEOAM_SHIFT_TILENUM; \
     (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_TILENUM; \
     (spritePtr)->attrib3 |= _tileNumVal; \
+}
+
+#define SpriteAddTileNum(spritePtr, addVal)         \
+{                                                \
+    u32 _tileNumValAdd;                                \
+    SpriteGetTileNum_LocalVar(spritePtr, _tileNumValAdd);            \
+    _tileNumValAdd += (addVal);                        \
+    SpriteSetTileNum(spritePtr, _tileNumValAdd);              \
 }
 
 #define SpriteSetPriority(spritePtr, _priority) \
@@ -233,6 +248,8 @@ typedef struct SpriteOAM
     (spritePtr)->attrib2 |= _sizeVal;                        \
 }
 
+#define SpriteGetX(spritePtr)(((spritePtr)->attrib2 >> SPRITEOAM_SHIFT_X) & SPRITEOAM_MAX_X)
+
 #define SpriteSetX(spritePtr, _x)                \
 {               \
     u32 _xSpriteVal = _x;               \
@@ -252,7 +269,9 @@ typedef struct SpriteOAM
     (spritePtr)->attrib2 = _xSpriteVal;               \
 }
 
-#define SpriteGetY(spritePtr, _y)             \
+#define SpriteGetY(spritePtr)(((spritePtr)->unk6 >> SPRITEOAM_SHIFT_WORKING_Y) & SPRITEOAM_MAX_WORKING_Y)
+
+#define SpriteGetY_LocalVar(spritePtr, _y)             \
 {                                            \
     _y = (spritePtr)->unk6;                \
     _y >>= SPRITEOAM_SHIFT_WORKING_Y;            \
@@ -271,7 +290,7 @@ typedef struct SpriteOAM
 #define SpriteAddY(spritePtr, addVal)         \
 {                                                \
     u32 _yVal;                                \
-    SpriteGetY(spritePtr, _yVal);            \
+    SpriteGetY_LocalVar(spritePtr, _yVal);            \
     _yVal += (addVal);                        \
     SpriteSetY(spritePtr, _yVal);              \
 }
@@ -284,6 +303,8 @@ typedef struct SpriteOAM
     (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_0; \
     (spritePtr)->unk6 |= _unk6_0Val; \
 }
+
+#define SpriteGetUnk6_1(spritePtr)(((spritePtr)->unk6 >> SPRITEOAM_SHIFT_UNK6_1) & SPRITEOAM_MAX_UNK6_1)
 
 #define SpriteSetUnk6_1(spritePtr, _unk6_1) \
 { \

--- a/include/structs/sprite_oam.h
+++ b/include/structs/sprite_oam.h
@@ -119,120 +119,129 @@ typedef struct SpriteOAM
 
 #define SpriteSetAffine1(spritePtr, _affine1) \
 { \
-    u32 affine1 = _affine1; \
-    affine1 &= SPRITEOAM_MAX_AFFINEMODE1; \
-    affine1 <<= SPRITEOAM_SHIFT_AFFINEMODE1; \
+    u32 _affine1Val = _affine1; \
+    _affine1Val &= SPRITEOAM_MAX_AFFINEMODE1; \
+    _affine1Val <<= SPRITEOAM_SHIFT_AFFINEMODE1; \
     (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1; \
-    (spritePtr)->attrib1 |= affine1; \
+    (spritePtr)->attrib1 |= _affine1Val; \
 }
 
 #define SpriteSetAffine2(spritePtr, _affine2) \
 { \
-    u32 affine2 = _affine2; \
-    affine2 &= SPRITEOAM_MAX_AFFINEMODE2; \
-    affine2 <<= SPRITEOAM_SHIFT_AFFINEMODE2; \
+    u32 _affine2Val = _affine2; \
+    _affine2Val &= SPRITEOAM_MAX_AFFINEMODE2; \
+    _affine2Val <<= SPRITEOAM_SHIFT_AFFINEMODE2; \
     (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2; \
-    (spritePtr)->attrib1 |= affine2; \
+    (spritePtr)->attrib1 |= _affine2Val; \
 }
 
 #define SpriteSetObjMode(spritePtr, _objMode) \
 { \
-    u32 objMode = _objMode; \
-    objMode &= SPRITEOAM_MAX_OBJMODE; \
-    objMode <<= SPRITEOAM_SHIFT_OBJMODE; \
+    u32 _objModeVal = _objMode; \
+    _objModeVal &= SPRITEOAM_MAX_OBJMODE; \
+    _objModeVal <<= SPRITEOAM_SHIFT_OBJMODE; \
     (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_OBJMODE; \
-    (spritePtr)->attrib1 |= objMode; \
+    (spritePtr)->attrib1 |= _objModeVal; \
 }
 
 #define SpriteSetMosaic(spritePtr, _mosaic) \
 { \
-    u32 mosaic = _mosaic; \
-    mosaic &= SPRITEOAM_MAX_MOSAIC; \
-    mosaic <<= SPRITEOAM_SHIFT_MOSAIC; \
+    u32 _mosaicVal = _mosaic; \
+    _mosaicVal &= SPRITEOAM_MAX_MOSAIC; \
+    _mosaicVal <<= SPRITEOAM_SHIFT_MOSAIC; \
     (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_MOSAIC; \
-    (spritePtr)->attrib1 |= mosaic; \
+    (spritePtr)->attrib1 |= _mosaicVal; \
 }
 
 #define SpriteSetBpp(spritePtr, _bpp) \
 { \
-    u32 bpp = _bpp; \
-    bpp &= SPRITEOAM_MAX_BPP; \
-    bpp <<= SPRITEOAM_SHIFT_BPP; \
+    u32 _bppVal = _bpp; \
+    _bppVal &= SPRITEOAM_MAX_BPP; \
+    _bppVal <<= SPRITEOAM_SHIFT_BPP; \
     (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_BPP; \
-    (spritePtr)->attrib1 |= bpp; \
+    (spritePtr)->attrib1 |= _bppVal; \
 }
 
 #define SpriteSetShape(spritePtr, _shape) \
 { \
-    u32 shape = _shape; \
-    shape &= SPRITEOAM_MAX_SHAPE; \
-    shape <<= SPRITEOAM_SHIFT_SHAPE; \
+    u32 _shapeVal = _shape; \
+    _shapeVal &= SPRITEOAM_MAX_SHAPE; \
+    _shapeVal <<= SPRITEOAM_SHIFT_SHAPE; \
     (spritePtr)->attrib1 &= ~SPRITEOAM_MASK_SHAPE; \
-    (spritePtr)->attrib1 |= shape; \
+    (spritePtr)->attrib1 |= _shapeVal; \
 }
 
 #define SpriteSetTileNum(spritePtr, _tileNum) \
 { \
-    u32 tileNum = _tileNum; \
-    tileNum &= SPRITEOAM_MAX_TILENUM; \
-    tileNum <<= SPRITEOAM_SHIFT_TILENUM; \
+    u32 _tileNumVal = _tileNum; \
+    _tileNumVal &= SPRITEOAM_MAX_TILENUM; \
+    _tileNumVal <<= SPRITEOAM_SHIFT_TILENUM; \
     (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_TILENUM; \
-    (spritePtr)->attrib3 |= tileNum; \
+    (spritePtr)->attrib3 |= _tileNumVal; \
 }
 
 #define SpriteSetPriority(spritePtr, _priority) \
 { \
-    u32 priority = _priority; \
-    priority &= SPRITEOAM_MAX_PRIORITY; \
-    priority <<= SPRITEOAM_SHIFT_PRIORITY; \
+    u32 _priorityVal = _priority; \
+    _priorityVal &= SPRITEOAM_MAX_PRIORITY; \
+    _priorityVal <<= SPRITEOAM_SHIFT_PRIORITY; \
     (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_PRIORITY; \
-    (spritePtr)->attrib3 |= priority; \
+    (spritePtr)->attrib3 |= _priorityVal; \
 }
 
 #define SpriteSetPalNum(spritePtr, _palNum)                \
 {                                                       \
-    u32 palNum = _palNum;                               \
-    palNum &= SPRITEOAM_MAX_PALETTENUM;                \
-    palNum <<= SPRITEOAM_SHIFT_PALETTENUM;                \
+    u32 _palNumVal = _palNum;                               \
+    _palNumVal &= SPRITEOAM_MAX_PALETTENUM;                \
+    _palNumVal <<= SPRITEOAM_SHIFT_PALETTENUM;                \
     (spritePtr)->attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;            \
-    (spritePtr)->attrib3 |= palNum;                        \
+    (spritePtr)->attrib3 |= _palNumVal;                        \
 }
 
 #define SpriteSetMatrixNum(spritePtr, _matrixNum)                \
 {                                                       \
-    u32 matrixNum = _matrixNum;                               \
-    matrixNum &= SPRITEOAM_MAX_MATRIXNUM;                \
-    matrixNum <<= SPRITEOAM_SHIFT_MATRIXNUM;                \
+    u32 _matrixNumVal = _matrixNum;                               \
+    _matrixNumVal &= SPRITEOAM_MAX_MATRIXNUM;                \
+    _matrixNumVal <<= SPRITEOAM_SHIFT_MATRIXNUM;                \
     (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;            \
-    (spritePtr)->attrib2 |= matrixNum;                        \
+    (spritePtr)->attrib2 |= _matrixNumVal;                        \
+}
+
+// Needed for TryCreateModeArrows. No difference to SpriteSetMatrixNum other than not creating one additional local variable.
+#define SpriteSetMatrixNum_UseLocalVar(spritePtr, _matrixNum)                \
+{                                                       \
+    _matrixNum &= SPRITEOAM_MAX_MATRIXNUM;                \
+    _matrixNum <<= SPRITEOAM_SHIFT_MATRIXNUM;                \
+    (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;            \
+    (spritePtr)->attrib2 |= _matrixNum;                        \
 }
 
 #define SpriteSetSize(spritePtr, _size)                \
 {                                                       \
-    u32 size = _size;                               \
-    size &= SPRITEOAM_MAX_SIZE;                \
-    size <<= SPRITEOAM_SHIFT_SIZE;                \
+    u32 _sizeVal = _size;                               \
+    _sizeVal &= SPRITEOAM_MAX_SIZE;                \
+    _sizeVal <<= SPRITEOAM_SHIFT_SIZE;                \
     (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_SIZE;            \
-    (spritePtr)->attrib2 |= size;                        \
+    (spritePtr)->attrib2 |= _sizeVal;                        \
 }
 
 #define SpriteSetX(spritePtr, _x)                \
 {               \
-    u32 xSpriteVal = _x;               \
-    xSpriteVal &= SPRITEOAM_MAX_X;               \
-    xSpriteVal <<= SPRITEOAM_SHIFT_X;               \
+    u32 _xSpriteVal = _x;               \
+    _xSpriteVal &= SPRITEOAM_MAX_X;               \
+    _xSpriteVal <<= SPRITEOAM_SHIFT_X;               \
     (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_X;               \
-    (spritePtr)->attrib2 |= xSpriteVal;               \
+    (spritePtr)->attrib2 |= _xSpriteVal;               \
 }
 
 // Hacky way of matching functions in menu_input.c AddMenuCursorSprite_, sub_801332C sub_8013470
 #define SpriteSetX_MatrixNumSize0(spritePtr, _x)                \
 {               \
-    u32 xSpriteVal = _x;               \
-    xSpriteVal &= SPRITEOAM_MAX_X;               \
-    xSpriteVal <<= SPRITEOAM_SHIFT_X;               \
+    u32 _xSpriteVal = _x;               \
+    _xSpriteVal &= SPRITEOAM_MAX_X;               \
+    _xSpriteVal <<= SPRITEOAM_SHIFT_X;               \
     (spritePtr)->attrib2 &= ~SPRITEOAM_MASK_X;               \
-    (spritePtr)->attrib2 = xSpriteVal;               \
+    (spritePtr)->attrib2 = _xSpriteVal;               \
 }
 
 #define SpriteGetY(spritePtr, _y)             \
@@ -244,11 +253,11 @@ typedef struct SpriteOAM
 
 #define SpriteSetY(spritePtr, _y) \
 { \
-    u32 ySpriteVal = _y; \
-    ySpriteVal &= SPRITEOAM_MAX_UNK6_4; \
-    ySpriteVal <<= SPRITEOAM_SHIFT_UNK6_4; \
+    u32 _ySpriteVal = _y; \
+    _ySpriteVal &= SPRITEOAM_MAX_UNK6_4; \
+    _ySpriteVal <<= SPRITEOAM_SHIFT_UNK6_4; \
     (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_4; \
-    (spritePtr)->unk6 |= ySpriteVal; \
+    (spritePtr)->unk6 |= _ySpriteVal; \
 }
 
 #define SpriteAddY(spritePtr, addVal)         \
@@ -261,29 +270,29 @@ typedef struct SpriteOAM
 
 #define SpriteSetUnk6_0(spritePtr, _unk6_0) \
 { \
-    u32 unk6_0 = _unk6_0; \
-    unk6_0 &= SPRITEOAM_MAX_UNK6_0; \
-    unk6_0 <<= SPRITEOAM_SHIFT_UNK6_0; \
+    u32 _unk6_0Val = _unk6_0; \
+    _unk6_0Val &= SPRITEOAM_MAX_UNK6_0; \
+    _unk6_0Val <<= SPRITEOAM_SHIFT_UNK6_0; \
     (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_0; \
-    (spritePtr)->unk6 |= unk6_0; \
+    (spritePtr)->unk6 |= _unk6_0Val; \
 }
 
 #define SpriteSetUnk6_1(spritePtr, _unk6_1) \
 { \
-    u32 unk6_1 = _unk6_1; \
-    unk6_1 &= SPRITEOAM_MAX_UNK6_1; \
-    unk6_1 <<= SPRITEOAM_SHIFT_UNK6_1; \
+    u32 _unk6_1Val = _unk6_1; \
+    _unk6_1Val &= SPRITEOAM_MAX_UNK6_1; \
+    _unk6_1Val <<= SPRITEOAM_SHIFT_UNK6_1; \
     (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_1; \
-    (spritePtr)->unk6 |= unk6_1; \
+    (spritePtr)->unk6 |= _unk6_1Val; \
 }
 
 #define SpriteSetUnk6_2(spritePtr, _unk6_2) \
 { \
-    u32 unk6_2 = _unk6_2; \
-    unk6_2 &= SPRITEOAM_MAX_UNK6_2; \
-    unk6_2 <<= SPRITEOAM_SHIFT_UNK6_2; \
+    u32 _unk6_2Val = _unk6_2; \
+    _unk6_2Val &= SPRITEOAM_MAX_UNK6_2; \
+    _unk6_2Val <<= SPRITEOAM_SHIFT_UNK6_2; \
     (spritePtr)->unk6 &= ~SPRITEOAM_MASK_UNK6_2; \
-    (spritePtr)->unk6 |= unk6_2; \
+    (spritePtr)->unk6 |= _unk6_2Val; \
 }
 
 #endif // GUARD_SPRITE_OAM_H

--- a/src/code_803E724.c
+++ b/src/code_803E724.c
@@ -367,52 +367,23 @@ void sub_803EDF0(void)
 
     // sprite oam memes strike again
     if (x >= -32 && y >= -8 && x < 240 && y < 160) {
-        u32 r9;
-        u32 unk6;
-        u32 shape, spriteX, palNum, prio, tileNum;
+        SpriteSetY(&gUnknown_202EDDC, y);
+        SpriteSetAffine1(&gUnknown_202EDDC, 0);
+        SpriteSetAffine2(&gUnknown_202EDDC, 0);
+        SpriteSetObjMode(&gUnknown_202EDDC, 0);
+        SpriteSetMosaic(&gUnknown_202EDDC, 0);
+        SpriteSetBpp(&gUnknown_202EDDC, 0);
+        SpriteSetShape(&gUnknown_202EDDC, 1);
+        SpriteSetX(&gUnknown_202EDDC, x);
+        SpriteSetMatrixNum(&gUnknown_202EDDC, 0);
+        SpriteSetSize(&gUnknown_202EDDC, 1);
+        SpriteSetTileNum(&gUnknown_202EDDC, 0x216);
+        SpriteSetPriority(&gUnknown_202EDDC, gDungeon->unk181e8.unk18208);
+        SpriteSetPalNum(&gUnknown_202EDDC, gUnknown_202EDE8.unk2);
 
-        unk6 = y & SPRITEOAM_MAX_UNK6_4;
-        unk6 <<= SPRITEOAM_SHIFT_UNK6_4;
-        gUnknown_202EDDC.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-        gUnknown_202EDDC.unk6 |= unk6;
-
-        gUnknown_202EDDC.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-        gUnknown_202EDDC.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-        r9 = 3;
-        gUnknown_202EDDC.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-        gUnknown_202EDDC.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-        gUnknown_202EDDC.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-        shape = 1 << SPRITEOAM_SHIFT_SHAPE;
-        gUnknown_202EDDC.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-        gUnknown_202EDDC.attrib1 |= shape;
-
-        spriteX = x & SPRITEOAM_MAX_X;
-        gUnknown_202EDDC.attrib2 &= ~SPRITEOAM_MASK_X;
-        gUnknown_202EDDC.attrib2 |= spriteX;
-
-        gUnknown_202EDDC.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-        gUnknown_202EDDC.attrib2 &= ~SPRITEOAM_MASK_SIZE;
-        gUnknown_202EDDC.attrib2 |= 1 << SPRITEOAM_SHIFT_SIZE;
-
-        tileNum = 0x216 << SPRITEOAM_SHIFT_TILENUM;
-        gUnknown_202EDDC.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-        gUnknown_202EDDC.attrib3 |= tileNum;
-
-        prio = gDungeon->unk181e8.unk18208 & r9;
-        prio <<= SPRITEOAM_SHIFT_PRIORITY;
-        gUnknown_202EDDC.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-        gUnknown_202EDDC.attrib3 |= prio;
-
-        palNum = gUnknown_202EDE8.unk2;
-        palNum &= 0xF;
-        palNum <<= SPRITEOAM_SHIFT_PALETTENUM;
-        gUnknown_202EDDC.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-        gUnknown_202EDDC.attrib3 |= palNum;
-
-        gUnknown_202EDDC.unk6 &= ~SPRITEOAM_MASK_UNK6_0;
-        gUnknown_202EDDC.unk6 &= ~SPRITEOAM_MASK_UNK6_1;
-        gUnknown_202EDDC.unk6 &= ~SPRITEOAM_MASK_UNK6_2;
+        SpriteSetUnk6_0(&gUnknown_202EDDC, 0);
+        SpriteSetUnk6_1(&gUnknown_202EDDC, 0);
+        SpriteSetUnk6_2(&gUnknown_202EDDC, 0);
 
         AddSprite(&gUnknown_202EDDC, 0x100, NULL, NULL);
     }

--- a/src/code_805D8C8_1.c
+++ b/src/code_805D8C8_1.c
@@ -624,8 +624,6 @@ struct UnkStruct_8106AE8
 
 extern const struct UnkStruct_8106AE8 gUnknown_8106AE8[];
 
-#ifdef NONMATCHING
-// Sprite OAM memes. https://decomp.me/scratch/Jm4oC
 // Creates arrow sprites which are used when in rotate or diagonal modes.
 static void TryCreateModeArrows(Entity *leader)
 {
@@ -636,145 +634,90 @@ static void TryCreateModeArrows(Entity *leader)
         SpriteOAM sprite;
 
         for (i = 0; i < 4; i++) {
-            u32 objMode, matrixNum, tileNum, prio, xSprite, unk6;
+            u32 matrixNum;
             s32 x, xMul, x2;
-            s32 unk1, unk1Mul, unk2;
+            s32 y, yMul, y2;
 
-            sprite.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-            sprite.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
+            SpriteSetAffine1(&sprite, 0);
+            SpriteSetAffine2(&sprite, 0);
+            SpriteSetObjMode(&sprite, 1);
+            SpriteSetMosaic(&sprite, 0);
+            SpriteSetBpp(&sprite, 0);
+            SpriteSetShape(&sprite, 0);
 
-            objMode = 1 << SPRITEOAM_SHIFT_OBJMODE;
-            sprite.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-            sprite.attrib1 |= objMode;
-
-            sprite.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-            sprite.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-            sprite.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-
-            if (gUnknown_8106AC8[i].unk4 != 0)
-                matrixNum = 8;
-            else
-                matrixNum = 0;
+            matrixNum = (gUnknown_8106AC8[i].unk4 != 0) ? 8 : 0;
 
             if (gUnknown_8106AC8[i].unk5)
                 matrixNum += 16;
 
-            matrixNum &= SPRITEOAM_MAX_MATRIXNUM;
-            matrixNum <<= SPRITEOAM_SHIFT_MATRIXNUM;
-            sprite.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-            sprite.attrib2 |= matrixNum;
+            SpriteSetMatrixNum_UseLocalVar(&sprite, matrixNum);
+            SpriteSetSize(&sprite, 0);
 
-            sprite.attrib2 &= ~SPRITEOAM_MASK_SHAPE;
+            SpriteSetTileNum(&sprite, 0x213);
+            SpriteSetPriority(&sprite, 2);
+            SpriteSetPalNum(&sprite, 0);
 
-            tileNum = 0x213 << SPRITEOAM_SHIFT_TILENUM;
-            sprite.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-            sprite.attrib3 |= tileNum;
+            SpriteSetUnk6_0(&sprite, 0);
+            SpriteSetUnk6_1(&sprite, 0);
 
-            prio = 2 << SPRITEOAM_SHIFT_PRIORITY;
-            sprite.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-            sprite.attrib3 |= prio;
-
-            sprite.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-
-            sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_0;
-            sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_1;
-
-            x = gUnknown_8106AC8[i].unk0;
-            xMul = x * 10;
+            xMul = gUnknown_8106AC8[i].unk0 * 10;
             x2 = (sArrowsFrames / 2) & 7;
-            xSprite = xMul + 116 + (x2 * x);
-            xSprite &= SPRITEOAM_MAX_X;
-            xSprite <<= SPRITEOAM_SHIFT_X;
-            sprite.attrib2 &= ~SPRITEOAM_MASK_X;
-            sprite.attrib2 |= xSprite;
+            x = (x2 * gUnknown_8106AC8[i].unk0) + xMul + 116;
+            SpriteSetX(&sprite, x);
 
-            unk1 = gUnknown_8106AC8[i].unk2;
-            unk1Mul = unk1 * 10;
-            unk2 = (sArrowsFrames / 2) & 7;
-            unk6 = 82 + unk1Mul + (unk2 * unk1);
-            unk6 &= SPRITEOAM_MAX_UNK6_4;
-            unk6 <<= SPRITEOAM_SHIFT_UNK6_4;
-            sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-            sprite.unk6 |= unk6;
+            yMul = gUnknown_8106AC8[i].unk2 * 10;
+            y2 = (sArrowsFrames / 2) & 7;
+            y = (y2 * gUnknown_8106AC8[i].unk2) + yMul + 82;
+            SpriteSetY(&sprite, y);
 
             AddSprite(&sprite, 0x100, NULL, NULL);
         }
     }
+
     else if (unkPtr->unk1821A) {
-        s32 i, to;
+        s32 i;
         SpriteOAM sprite;
         s32 var_2C = unkPtr->unk1821B;
-        s32 x, y;
-        s32 x1, x2, xMul;
-        s32 y1, y2, yMul;
 
-        if (var_2C < 8u) {
-            to = (sShowThreeArrows2 != 0 && sShowThreeArrows1 != 0) ? 3 : 1;
+        if (unkPtr->unk1821B < 8) {
+            s32 x, xMul, x2;
+            s32 y, yMul, y2;
+            s32 to = (sShowThreeArrows2 != FALSE && sShowThreeArrows1 != FALSE) ? 3 : 1;
 
-            x1 = gUnknown_8106AE8[var_2C].unk0;
-            xMul = x1 * 10;
+            xMul = gUnknown_8106AE8[var_2C].unk0 * 10;
             x2 = (sArrowsFrames / 2) & 7;
-            x =  xMul + 116 + (x1 * x2);
+            x = (gUnknown_8106AE8[var_2C].unk0 * x2) + xMul + 116;
 
-            y1 = gUnknown_8106AE8[var_2C].unk2;
-            yMul = y1 * 10;
+            yMul = gUnknown_8106AE8[var_2C].unk2 * 10;
             y2 = (sArrowsFrames / 2) & 7;
-            y = 82 + yMul + (y2 * y1);
+            y = (y2 * gUnknown_8106AE8[var_2C].unk2) + yMul + 82;
             for (i = 0; i < to; i++) {
-                u32 objMode, tileNum, prio, matrixNum, xSprite, ySprite;
+                u32 matrixNum;
 
-                sprite.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-                sprite.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
+                SpriteSetAffine1(&sprite, 0);
+                SpriteSetAffine2(&sprite, 0);
+                SpriteSetObjMode(&sprite, 1);
+                SpriteSetMosaic(&sprite, 0);
+                SpriteSetBpp(&sprite, 0);
+                SpriteSetShape(&sprite, 0);
 
-                objMode = 1 << SPRITEOAM_SHIFT_OBJMODE;
-                sprite.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-                sprite.attrib1 |= objMode;
-
-                sprite.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-                sprite.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-                sprite.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-
-                if (gUnknown_8106AE8[var_2C].unk8 != 0)
-                    matrixNum = 8;
-                else
-                    matrixNum = 0;
+                matrixNum = (gUnknown_8106AE8[var_2C].unk8 != 0) ? 8 : 0;
 
                 if (gUnknown_8106AE8[var_2C].unk9)
                     matrixNum += 16;
 
-                matrixNum &= SPRITEOAM_MAX_MATRIXNUM;
-                matrixNum <<= SPRITEOAM_SHIFT_MATRIXNUM;
-                sprite.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-                sprite.attrib2 |= matrixNum;
+                SpriteSetMatrixNum_UseLocalVar(&sprite, matrixNum);
+                SpriteSetSize(&sprite, 0);
 
-                sprite.attrib2 &= ~SPRITEOAM_MASK_SIZE;
+                SpriteSetTileNum(&sprite, gUnknown_8106AE8[var_2C].unk4);
+                SpriteSetPriority(&sprite, 2);
+                SpriteSetPalNum(&sprite, 0);
 
-                tileNum = gUnknown_8106AE8[var_2C].unk4;
-                sprite.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-                sprite.attrib3 |= tileNum;
+                SpriteSetUnk6_0(&sprite, 0);
+                SpriteSetUnk6_1(&sprite, 0);
 
-                prio = 2 << SPRITEOAM_SHIFT_PRIORITY;
-                sprite.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-                sprite.attrib3 |= prio;
-
-                sprite.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-
-                sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_0;
-                sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_1;
-
-                xSprite = x;
-                xSprite &= SPRITEOAM_MAX_X;
-                xSprite <<= SPRITEOAM_SHIFT_X;
-                sprite.attrib2 &= ~SPRITEOAM_MASK_X;
-                sprite.attrib2 |= xSprite;
-
-                ySprite = y;
-                ySprite &= SPRITEOAM_MAX_UNK6_4;
-                ySprite <<= SPRITEOAM_SHIFT_UNK6_4;
-                sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-                sprite.unk6 |= ySprite;
+                SpriteSetX(&sprite, x);
+                SpriteSetY(&sprite, y);
 
                 AddSprite(&sprite, 0x100, NULL, NULL);
                 x += gUnknown_8106AE8[var_2C].unk0 * 4;
@@ -788,558 +731,6 @@ static void TryCreateModeArrows(Entity *leader)
         sub_804A728(&leader->pos, unkPtr->unk1821B, 0, sInRotateMode);
     }
 }
-
-#else
-NAKED static void TryCreateModeArrows(Entity *leader)
-{
-    asm_unified(	"\n"
-"	push {r4-r7,lr}\n"
-"	mov r7, r10\n"
-"	mov r6, r9\n"
-"	mov r5, r8\n"
-"	push {r5-r7}\n"
-"	sub sp, 0x28\n"
-"	str r0, [sp, 0x10]\n"
-"	ldr r0, _0805E47C\n"
-"	ldr r1, [r0]\n"
-"	ldr r0, _0805E480\n"
-"	adds r0, r1, r0\n"
-"	str r0, [sp, 0x14]\n"
-"	ldr r0, _0805E484\n"
-"	ldrb r0, [r0]\n"
-"	cmp r0, 0\n"
-"	bne _0805E2E6\n"
-"	b _0805E4C4\n"
-"_0805E2E6:\n"
-"	movs r1, 0\n"
-"	str r1, [sp, 0x18]\n"
-"	mov r7, sp\n"
-"	ldr r2, _0805E488\n"
-"	mov r10, r2\n"
-"_0805E2F0:\n"
-"	ldrh r0, [r7]\n"
-"	ldr r3, _0805E48C\n"
-"	adds r1, r3, 0\n"
-"	ands r1, r0\n"
-"	ldr r0, [sp]\n"
-"	mov r4, r10\n"
-"	ands r0, r4\n"
-"	orrs r0, r1\n"
-"	str r0, [sp]\n"
-"	ldrh r1, [r7]\n"
-"	mov r2, r10\n"
-"	ands r2, r0\n"
-"	orrs r2, r1\n"
-"	str r2, [sp]\n"
-"	ldrh r0, [r7]\n"
-"	ldr r5, _0805E490\n"
-"	adds r1, r5, 0\n"
-"	ands r1, r0\n"
-"	mov r0, r10\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	str r0, [sp]\n"
-"	ldrh r2, [r7]\n"
-"	mov r1, r10\n"
-"	ands r1, r0\n"
-"	orrs r1, r2\n"
-"	str r1, [sp]\n"
-"	ldrh r2, [r7]\n"
-"	ldr r0, _0805E494\n"
-"	ands r0, r2\n"
-"	mov r3, r10\n"
-"	ands r3, r1\n"
-"	orrs r3, r0\n"
-"	str r3, [sp]\n"
-"	ldrh r1, [r7]\n"
-"	movs r0, 0x80\n"
-"	lsls r0, 3\n"
-"	orrs r0, r1\n"
-"	movs r6, 0\n"
-"	orrs r0, r6\n"
-"	mov r2, r10\n"
-"	ands r2, r3\n"
-"	orrs r2, r0\n"
-"	str r2, [sp]\n"
-"	ldrh r0, [r7]\n"
-"	ldr r3, _0805E498\n"
-"	adds r1, r3, 0\n"
-"	ands r1, r0\n"
-"	mov r0, r10\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	str r0, [sp]\n"
-"	ldrh r1, [r7]\n"
-"	mov r2, r10\n"
-"	ands r2, r0\n"
-"	orrs r2, r1\n"
-"	str r2, [sp]\n"
-"	ldrh r0, [r7]\n"
-"	ldr r4, _0805E49C\n"
-"	adds r1, r4, 0\n"
-"	ands r1, r0\n"
-"	mov r0, r10\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	str r0, [sp]\n"
-"	ldrh r1, [r7]\n"
-"	mov r2, r10\n"
-"	ands r2, r0\n"
-"	orrs r2, r1\n"
-"	str r2, [sp]\n"
-"	ldrh r1, [r7]\n"
-"	ldr r0, _0805E4A0\n"
-"	ands r0, r1\n"
-"	mov r1, r10\n"
-"	ands r1, r2\n"
-"	orrs r1, r0\n"
-"	str r1, [sp]\n"
-"	ldrh r2, [r7]\n"
-"	mov r0, r10\n"
-"	ands r0, r1\n"
-"	orrs r0, r2\n"
-"	str r0, [sp]\n"
-"	ldr r1, _0805E4A4\n"
-"	ldr r5, [sp, 0x18]\n"
-"	lsls r0, r5, 3\n"
-"	adds r0, r1\n"
-"	mov r12, r0\n"
-"	ldrb r1, [r0, 0x4]\n"
-"	negs r0, r1\n"
-"	orrs r0, r1\n"
-"	asrs r1, r0, 31\n"
-"	movs r0, 0x8\n"
-"	ands r1, r0\n"
-"	mov r6, r12\n"
-"	ldrb r0, [r6, 0x5]\n"
-"	cmp r0, 0\n"
-"	beq _0805E3B4\n"
-"	adds r1, 0x10\n"
-"_0805E3B4:\n"
-"	movs r0, 0x1F\n"
-"	ands r1, r0\n"
-"	lsls r1, 9\n"
-"	ldrh r3, [r7, 0x2]\n"
-"	ldr r2, _0805E4A8\n"
-"	adds r0, r2, 0\n"
-"	ands r3, r0\n"
-"	orrs r3, r1\n"
-"	ldr r4, _0805E4A0\n"
-"	ands r3, r4\n"
-"	strh r3, [r7, 0x2]\n"
-"	ldr r2, _0805E4AC\n"
-"	ldrh r0, [r7, 0x4]\n"
-"	movs r5, 0xFC\n"
-"	lsls r5, 8\n"
-"	adds r1, r5, 0\n"
-"	ands r0, r1\n"
-"	orrs r0, r2\n"
-"	movs r6, 0\n"
-"	orrs r0, r6\n"
-"	movs r1, 0x80\n"
-"	lsls r1, 4\n"
-"	ldr r2, _0805E494\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	orrs r0, r6\n"
-"	ldr r4, _0805E4B0\n"
-"	mov r9, r4\n"
-"	ands r0, r4\n"
-"	strh r0, [r7, 0x4]\n"
-"	ldrh r4, [r7, 0x6]\n"
-"	ldr r5, _0805E4B4\n"
-"	adds r0, r5, 0\n"
-"	ands r4, r0\n"
-"	ldr r6, _0805E4B8\n"
-"	adds r0, r6, 0\n"
-"	ands r4, r0\n"
-"	strh r4, [r7, 0x6]\n"
-"	mov r0, r12\n"
-"	movs r1, 0\n"
-"	ldrsh r5, [r0, r1]\n"
-"	lsls r2, r5, 2\n"
-"	adds r2, r5\n"
-"	lsls r2, 1\n"
-"	ldr r6, _0805E4BC\n"
-"	mov r8, r6\n"
-"	movs r1, 0\n"
-"	ldrsh r0, [r6, r1]\n"
-"	lsrs r1, r0, 31\n"
-"	adds r0, r1\n"
-"	asrs r0, 1\n"
-"	movs r6, 0x7\n"
-"	ands r0, r6\n"
-"	muls r0, r5\n"
-"	adds r0, r2\n"
-"	adds r0, 0x74\n"
-"	ldr r1, _0805E4C0\n"
-"	ands r0, r1\n"
-"	movs r2, 0xFE\n"
-"	lsls r2, 8\n"
-"	adds r1, r2, 0\n"
-"	ands r3, r1\n"
-"	orrs r3, r0\n"
-"	strh r3, [r7, 0x2]\n"
-"	mov r5, r12\n"
-"	movs r0, 0x2\n"
-"	ldrsh r3, [r5, r0]\n"
-"	lsls r2, r3, 2\n"
-"	adds r2, r3\n"
-"	lsls r2, 1\n"
-"	mov r1, r8\n"
-"	movs r5, 0\n"
-"	ldrsh r0, [r1, r5]\n"
-"	lsrs r1, r0, 31\n"
-"	adds r0, r1\n"
-"	asrs r0, 1\n"
-"	ands r0, r6\n"
-"	muls r0, r3\n"
-"	adds r0, r2\n"
-"	adds r0, 0x52\n"
-"	mov r6, r9\n"
-"	ands r0, r6\n"
-"	lsls r0, 4\n"
-"	movs r1, 0xF\n"
-"	ands r4, r1\n"
-"	orrs r4, r0\n"
-"	strh r4, [r7, 0x6]\n"
-"	mov r0, sp\n"
-"	adds r1, 0xF1\n"
-"	movs r2, 0\n"
-"	movs r3, 0\n"
-"	bl AddSprite\n"
-"	ldr r2, [sp, 0x18]\n"
-"	adds r2, 0x1\n"
-"	str r2, [sp, 0x18]\n"
-"	cmp r2, 0x3\n"
-"	bgt _0805E47A\n"
-"	b _0805E2F0\n"
-"_0805E47A:\n"
-"	b _0805E6AC\n"
-"	.align 2, 0\n"
-"_0805E47C: .4byte gDungeon\n"
-"_0805E480: .4byte 0x000181e8\n"
-"_0805E484: .4byte sInDiagonalMode\n"
-"_0805E488: .4byte 0xffff0000\n"
-"_0805E48C: .4byte 0x0000feff\n"
-"_0805E490: .4byte 0x0000fdff\n"
-"_0805E494: .4byte 0x0000f3ff\n"
-"_0805E498: .4byte 0x0000efff\n"
-"_0805E49C: .4byte 0x0000dfff\n"
-"_0805E4A0: .4byte 0x00003fff\n"
-"_0805E4A4: .4byte gUnknown_8106AC8\n"
-"_0805E4A8: .4byte 0x0000c1ff\n"
-"_0805E4AC: .4byte 0x00000213\n"
-"_0805E4B0: .4byte 0x00000fff\n"
-"_0805E4B4: .4byte 0x0000fffe\n"
-"_0805E4B8: .4byte 0x0000fffd\n"
-"_0805E4BC: .4byte sArrowsFrames\n"
-"_0805E4C0: .4byte 0x000001ff\n"
-"_0805E4C4:\n"
-"	ldr r3, _0805E6E4\n"
-"	adds r0, r1, r3\n"
-"	ldrb r0, [r0]\n"
-"	cmp r0, 0\n"
-"	bne _0805E4D0\n"
-"	b _0805E6AC\n"
-"_0805E4D0:\n"
-"	ldr r4, _0805E6E8\n"
-"	adds r0, r1, r4\n"
-"	ldrb r0, [r0]\n"
-"	str r0, [sp, 0x1C]\n"
-"	cmp r0, 0x7\n"
-"	bls _0805E4DE\n"
-"	b _0805E6AC\n"
-"_0805E4DE:\n"
-"	ldr r0, _0805E6EC\n"
-"	ldrb r0, [r0]\n"
-"	movs r7, 0x1\n"
-"	cmp r0, 0\n"
-"	beq _0805E4F2\n"
-"	ldr r0, _0805E6F0\n"
-"	ldrb r0, [r0]\n"
-"	cmp r0, 0\n"
-"	beq _0805E4F2\n"
-"	movs r7, 0x3\n"
-"_0805E4F2:\n"
-"	ldr r5, _0805E6F4\n"
-"	mov r12, r5\n"
-"	ldr r6, [sp, 0x1C]\n"
-"	lsls r5, r6, 1\n"
-"	adds r3, r5, r6\n"
-"	lsls r3, 2\n"
-"	add r3, r12\n"
-"	movs r0, 0\n"
-"	ldrsh r4, [r3, r0]\n"
-"	lsls r1, r4, 2\n"
-"	adds r1, r4\n"
-"	lsls r1, 1\n"
-"	ldr r0, _0805E6F8\n"
-"	movs r6, 0\n"
-"	ldrsh r2, [r0, r6]\n"
-"	lsrs r0, r2, 31\n"
-"	adds r2, r0\n"
-"	asrs r2, 1\n"
-"	movs r0, 0x7\n"
-"	ands r2, r0\n"
-"	adds r0, r4, 0\n"
-"	muls r0, r2\n"
-"	adds r0, r1\n"
-"	adds r0, 0x74\n"
-"	str r0, [sp, 0x20]\n"
-"	movs r1, 0x2\n"
-"	ldrsh r0, [r3, r1]\n"
-"	lsls r1, r0, 2\n"
-"	adds r1, r0\n"
-"	lsls r1, 1\n"
-"	muls r0, r2\n"
-"	adds r0, r1\n"
-"	adds r0, 0x52\n"
-"	mov r10, r0\n"
-"	str r5, [sp, 0x24]\n"
-"	cmp r7, 0\n"
-"	bne _0805E53E\n"
-"	b _0805E6AC\n"
-"_0805E53E:\n"
-"	add r6, sp, 0x8\n"
-"	ldr r2, _0805E6FC\n"
-"	mov r8, r2\n"
-"	mov r9, r7\n"
-"_0805E546:\n"
-"	ldrh r0, [r6]\n"
-"	ldr r3, _0805E700\n"
-"	adds r1, r3, 0\n"
-"	ands r1, r0\n"
-"	ldr r0, [sp, 0x8]\n"
-"	mov r4, r8\n"
-"	ands r0, r4\n"
-"	orrs r0, r1\n"
-"	str r0, [sp, 0x8]\n"
-"	ldrh r1, [r6]\n"
-"	mov r2, r8\n"
-"	ands r2, r0\n"
-"	orrs r2, r1\n"
-"	str r2, [sp, 0x8]\n"
-"	ldrh r0, [r6]\n"
-"	ldr r5, _0805E704\n"
-"	adds r1, r5, 0\n"
-"	ands r1, r0\n"
-"	mov r0, r8\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	str r0, [sp, 0x8]\n"
-"	ldrh r2, [r6]\n"
-"	mov r1, r8\n"
-"	ands r1, r0\n"
-"	orrs r1, r2\n"
-"	str r1, [sp, 0x8]\n"
-"	ldrh r2, [r6]\n"
-"	ldr r0, _0805E708\n"
-"	ands r0, r2\n"
-"	mov r3, r8\n"
-"	ands r3, r1\n"
-"	orrs r3, r0\n"
-"	str r3, [sp, 0x8]\n"
-"	ldrh r1, [r6]\n"
-"	movs r0, 0x80\n"
-"	lsls r0, 3\n"
-"	orrs r0, r1\n"
-"	movs r1, 0\n"
-"	orrs r0, r1\n"
-"	mov r2, r8\n"
-"	ands r2, r3\n"
-"	orrs r2, r0\n"
-"	str r2, [sp, 0x8]\n"
-"	ldrh r0, [r6]\n"
-"	ldr r3, _0805E70C\n"
-"	adds r1, r3, 0\n"
-"	ands r1, r0\n"
-"	mov r0, r8\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	str r0, [sp, 0x8]\n"
-"	ldrh r1, [r6]\n"
-"	mov r2, r8\n"
-"	ands r2, r0\n"
-"	orrs r2, r1\n"
-"	str r2, [sp, 0x8]\n"
-"	ldrh r0, [r6]\n"
-"	ldr r4, _0805E710\n"
-"	adds r1, r4, 0\n"
-"	ands r1, r0\n"
-"	mov r0, r8\n"
-"	ands r0, r2\n"
-"	orrs r0, r1\n"
-"	str r0, [sp, 0x8]\n"
-"	ldrh r1, [r6]\n"
-"	mov r2, r8\n"
-"	ands r2, r0\n"
-"	orrs r2, r1\n"
-"	str r2, [sp, 0x8]\n"
-"	ldrh r1, [r6]\n"
-"	ldr r0, _0805E714\n"
-"	ands r0, r1\n"
-"	mov r1, r8\n"
-"	ands r1, r2\n"
-"	orrs r1, r0\n"
-"	str r1, [sp, 0x8]\n"
-"	ldrh r2, [r6]\n"
-"	mov r0, r8\n"
-"	ands r0, r1\n"
-"	orrs r0, r2\n"
-"	str r0, [sp, 0x8]\n"
-"	ldr r5, [sp, 0x24]\n"
-"	ldr r1, [sp, 0x1C]\n"
-"	adds r0, r5, r1\n"
-"	lsls r2, r0, 2\n"
-"	ldr r3, _0805E6F4\n"
-"	adds r7, r2, r3\n"
-"	ldrb r1, [r7, 0x8]\n"
-"	negs r0, r1\n"
-"	orrs r0, r1\n"
-"	asrs r1, r0, 31\n"
-"	movs r0, 0x8\n"
-"	ands r1, r0\n"
-"	ldrb r0, [r7, 0x9]\n"
-"	cmp r0, 0\n"
-"	beq _0805E60A\n"
-"	adds r1, 0x10\n"
-"_0805E60A:\n"
-"	movs r0, 0x1F\n"
-"	ands r1, r0\n"
-"	lsls r1, 9\n"
-"	ldrh r3, [r6, 0x2]\n"
-"	ldr r4, _0805E718\n"
-"	adds r0, r4, 0\n"
-"	ands r3, r0\n"
-"	orrs r3, r1\n"
-"	ldr r5, _0805E714\n"
-"	ands r3, r5\n"
-"	strh r3, [r6, 0x2]\n"
-"	ldr r1, _0805E71C\n"
-"	adds r0, r2, r1\n"
-"	ldr r2, [r0]\n"
-"	ldr r0, _0805E720\n"
-"	ands r2, r0\n"
-"	ldrh r0, [r6, 0x4]\n"
-"	movs r4, 0xFC\n"
-"	lsls r4, 8\n"
-"	adds r1, r4, 0\n"
-"	ands r0, r1\n"
-"	orrs r0, r2\n"
-"	movs r1, 0x80\n"
-"	lsls r1, 4\n"
-"	ldr r5, _0805E708\n"
-"	ands r0, r5\n"
-"	orrs r0, r1\n"
-"	movs r1, 0\n"
-"	orrs r0, r1\n"
-"	movs r2, 0xF\n"
-"	mov r12, r2\n"
-"	ldr r4, _0805E724\n"
-"	ands r0, r4\n"
-"	strh r0, [r6, 0x4]\n"
-"	ldrh r1, [r6, 0x6]\n"
-"	ldr r5, _0805E728\n"
-"	adds r0, r5, 0\n"
-"	ands r1, r0\n"
-"	ldr r2, _0805E72C\n"
-"	adds r0, r2, 0\n"
-"	ands r1, r0\n"
-"	ldr r0, _0805E730\n"
-"	ldr r5, [sp, 0x20]\n"
-"	ands r0, r5\n"
-"	movs r5, 0xFE\n"
-"	lsls r5, 8\n"
-"	adds r2, r5, 0\n"
-"	ands r3, r2\n"
-"	orrs r3, r0\n"
-"	strh r3, [r6, 0x2]\n"
-"	mov r0, r10\n"
-"	ands r0, r4\n"
-"	lsls r0, 4\n"
-"	mov r2, r12\n"
-"	ands r1, r2\n"
-"	orrs r1, r0\n"
-"	strh r1, [r6, 0x6]\n"
-"	adds r0, r6, 0\n"
-"	movs r1, 0x80\n"
-"	lsls r1, 1\n"
-"	movs r2, 0\n"
-"	movs r3, 0\n"
-"	bl AddSprite\n"
-"	movs r3, 0\n"
-"	ldrsh r0, [r7, r3]\n"
-"	lsls r0, 2\n"
-"	ldr r4, [sp, 0x20]\n"
-"	adds r4, r0\n"
-"	str r4, [sp, 0x20]\n"
-"	movs r5, 0x2\n"
-"	ldrsh r0, [r7, r5]\n"
-"	lsls r0, 2\n"
-"	add r10, r0\n"
-"	movs r0, 0x1\n"
-"	negs r0, r0\n"
-"	add r9, r0\n"
-"	mov r1, r9\n"
-"	cmp r1, 0\n"
-"	beq _0805E6AC\n"
-"	b _0805E546\n"
-"_0805E6AC:\n"
-"	ldr r4, _0805E734\n"
-"	ldrb r0, [r4]\n"
-"	cmp r0, 0\n"
-"	beq _0805E6D4\n"
-"	ldr r2, [sp, 0x14]\n"
-"	adds r2, 0x34\n"
-"	ldr r3, [sp, 0x14]\n"
-"	adds r3, 0x33\n"
-"	ldrb r1, [r3]\n"
-"	ldrb r0, [r2]\n"
-"	cmp r0, r1\n"
-"	beq _0805E6D4\n"
-"	strb r1, [r2]\n"
-"	ldr r0, [sp, 0x10]\n"
-"	adds r0, 0x4\n"
-"	ldrb r1, [r3]\n"
-"	ldrb r3, [r4]\n"
-"	movs r2, 0\n"
-"	bl sub_804A728\n"
-"_0805E6D4:\n"
-"	add sp, 0x28\n"
-"	pop {r3-r5}\n"
-"	mov r8, r3\n"
-"	mov r9, r4\n"
-"	mov r10, r5\n"
-"	pop {r4-r7}\n"
-"	pop {r0}\n"
-"	bx r0\n"
-"	.align 2, 0\n"
-"_0805E6E4: .4byte 0x0001821a\n"
-"_0805E6E8: .4byte 0x0001821b\n"
-"_0805E6EC: .4byte sShowThreeArrows2\n"
-"_0805E6F0: .4byte sShowThreeArrows1\n"
-"_0805E6F4: .4byte gUnknown_8106AE8\n"
-"_0805E6F8: .4byte sArrowsFrames\n"
-"_0805E6FC: .4byte 0xffff0000\n"
-"_0805E700: .4byte 0x0000feff\n"
-"_0805E704: .4byte 0x0000fdff\n"
-"_0805E708: .4byte 0x0000f3ff\n"
-"_0805E70C: .4byte 0x0000efff\n"
-"_0805E710: .4byte 0x0000dfff\n"
-"_0805E714: .4byte 0x00003fff\n"
-"_0805E718: .4byte 0x0000c1ff\n"
-"_0805E71C: .4byte gUnknown_8106AE8 + 4\n"
-"_0805E720: .4byte 0x000003ff\n"
-"_0805E724: .4byte 0x00000fff\n"
-"_0805E728: .4byte 0x0000fffe\n"
-"_0805E72C: .4byte 0x0000fffd\n"
-"_0805E730: .4byte 0x000001ff\n"
-"_0805E734: .4byte sInRotateMode"
-);
-}
-
-#endif // NONMATCHING
 
 void sub_805E738(Entity *a0)
 {

--- a/src/code_8069E0C.c
+++ b/src/code_8069E0C.c
@@ -2290,18 +2290,8 @@ void sub_806C51C(Entity *entity)
     if (xSprite >= -32 && ySprite >= -32 && xSprite <= 271 && ySprite <= 191 && r7 != 6 && entity->unk22 == 0) {
         struct unkStruct_202ED28 *spriteStructPtr = &gUnknown_202ED28[var_34][r7];
         if (entInfo->unk156 != 0) {
-            u32 finalXSprite, finalYSprite;
-
-            finalXSprite = xSprite + spriteStructPtr->x;
-            finalXSprite &= SPRITEOAM_MASK_X;
-            spriteStructPtr->sprite.attrib2 &= ~SPRITEOAM_MASK_X;
-            spriteStructPtr->sprite.attrib2 |= finalXSprite;
-
-            finalYSprite = ySprite + spriteStructPtr->y;
-            finalYSprite &= SPRITEOAM_MAX_UNK6_4;
-            finalYSprite <<= SPRITEOAM_SHIFT_UNK6_4;
-            spriteStructPtr->sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-            spriteStructPtr->sprite.unk6 |= finalYSprite;
+            SpriteSetX(&spriteStructPtr->sprite, xSprite + spriteStructPtr->x);
+            SpriteSetY(&spriteStructPtr->sprite, ySprite + spriteStructPtr->y);
 
             AddSprite(&spriteStructPtr->sprite, 0, NULL, NULL);
         }

--- a/src/code_807E5AC.c
+++ b/src/code_807E5AC.c
@@ -1455,38 +1455,12 @@ void sub_807FA9C(void)
                 s32 spriteX = (x * 24) - gDungeon->unk181e8.cameraPixelPos.x;
                 s32 spriteY = (y * 24) - gDungeon->unk181e8.cameraPixelPos.y;
                 if (spriteX >= -32 && spriteY >= -32 && spriteX <= 272 && spriteY <= 192)  {
-                    u32 spriteXMasked, spriteYMasked, priority, palNum, tileNum, objMode;
-
-                    objMode = 0;
-                    objMode &= SPRITEOAM_MAX_OBJMODE;
-                    objMode <<= SPRITEOAM_SHIFT_OBJMODE;
-                    gUnknown_202EDC0.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-                    gUnknown_202EDC0.attrib1 |= objMode;
-
-                    spriteYMasked = (spriteY & SPRITEOAM_MAX_UNK6_4);
-                    spriteYMasked <<= SPRITEOAM_SHIFT_UNK6_4;
-                    gUnknown_202EDC0.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-                    gUnknown_202EDC0.unk6 |= spriteYMasked;
-
-                    spriteXMasked = (spriteX & SPRITEOAM_MAX_X);
-                    spriteXMasked <<= SPRITEOAM_SHIFT_X;
-                    gUnknown_202EDC0.attrib2 &= ~SPRITEOAM_MASK_X;
-                    gUnknown_202EDC0.attrib2 |= spriteXMasked;
-
-                    priority = 3 & SPRITEOAM_MAX_PRIORITY;
-                    priority <<= SPRITEOAM_SHIFT_PRIORITY;
-                    gUnknown_202EDC0.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-                    gUnknown_202EDC0.attrib3 |= priority;
-
-                    palNum = 10 & SPRITEOAM_MAX_PALETTENUM;
-                    palNum <<= SPRITEOAM_SHIFT_PALETTENUM;
-                    gUnknown_202EDC0.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-                    gUnknown_202EDC0.attrib3 |= palNum;
-
-                    tileNum = 0x1FC & SPRITEOAM_MAX_TILENUM;
-                    tileNum <<= SPRITEOAM_SHIFT_TILENUM;
-                    gUnknown_202EDC0.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-                    gUnknown_202EDC0.attrib3 |= tileNum;
+                    SpriteSetObjMode(&gUnknown_202EDC0, 0);
+                    SpriteSetY(&gUnknown_202EDC0, spriteY);
+                    SpriteSetX(&gUnknown_202EDC0, spriteX);
+                    SpriteSetPriority(&gUnknown_202EDC0, 3);
+                    SpriteSetPalNum(&gUnknown_202EDC0, 10);
+                    SpriteSetTileNum(&gUnknown_202EDC0, 0x1FC);
 
                     AddSprite(&gUnknown_202EDC0, 0, NULL, NULL);
                 }

--- a/src/code_808333C.c
+++ b/src/code_808333C.c
@@ -9,18 +9,8 @@ bool8 sub_8083568(s32 inX, s32 inY, u8 index)
 
     if (x >= -16 && y >= -16 && x <= 255 && y <= 175)
     {
-        u32 finalXSprite, finalYSprite;
-
-        finalXSprite = x + gUnknown_202ED28[0][index].x;
-        finalXSprite &= SPRITEOAM_MASK_X;
-        gUnknown_202ED28[0][index].sprite.attrib2 &= ~SPRITEOAM_MASK_X;
-        gUnknown_202ED28[0][index].sprite.attrib2 |= finalXSprite;
-
-        finalYSprite = y + gUnknown_202ED28[0][index].y;
-        finalYSprite &= SPRITEOAM_MAX_UNK6_4;
-        finalYSprite <<= SPRITEOAM_SHIFT_UNK6_4;
-        gUnknown_202ED28[0][index].sprite.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-        gUnknown_202ED28[0][index].sprite.unk6 |= finalYSprite;
+        SpriteSetX(&gUnknown_202ED28[0][index].sprite, x + gUnknown_202ED28[0][index].x);
+        SpriteSetY(&gUnknown_202ED28[0][index].sprite, y + gUnknown_202ED28[0][index].y);
 
         AddSprite(&gUnknown_202ED28[0][index].sprite, 0, NULL, NULL);
         return TRUE;

--- a/src/dungeon_message.c
+++ b/src/dungeon_message.c
@@ -763,41 +763,19 @@ void sub_8052FB8(const u8 *str)
         else {
             r9++;
             if (r9 & 8) {
-                u32 shape, tileNum, unk6, spriteX, mask, palNum;
-
-                sUnknown_202F1F0.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-                sUnknown_202F1F0.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-                sUnknown_202F1F0.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-                sUnknown_202F1F0.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-                sUnknown_202F1F0.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-                sUnknown_202F1F0.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-                shape = 1;
-                shape <<= SPRITEOAM_SHIFT_SHAPE;
-                ASM_MATCH_TRICK(shape);
-                sUnknown_202F1F0.attrib1 |= shape;
-
-                tileNum = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-                sUnknown_202F1F0.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-                sUnknown_202F1F0.attrib3 |= tileNum;
-
-                sUnknown_202F1F0.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-
-                mask = 0xF;
-                palNum = (15 & SPRITEOAM_MAX_PALETTENUM) << SPRITEOAM_SHIFT_PALETTENUM;
-                sUnknown_202F1F0.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-                sUnknown_202F1F0.attrib3 |= palNum;
-
-                unk6 = 0x78 << SPRITEOAM_SHIFT_UNK6_4;
-                sUnknown_202F1F0.unk6 &= mask; // ~SPRITEOAM_MASK_UNK6_4
-                sUnknown_202F1F0.unk6 |= unk6;
-
-                sUnknown_202F1F0.attrib2 &= ~SPRITEOAM_MASK_X;
-                sUnknown_202F1F0.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-
-                spriteX = 0x70 & SPRITEOAM_MAX_X;
-                sUnknown_202F1F0.attrib2 &= ~SPRITEOAM_MASK_SIZE;
-                sUnknown_202F1F0.attrib2 |= spriteX;
+                SpriteSetAffine1(&sUnknown_202F1F0, 0);
+                SpriteSetAffine2(&sUnknown_202F1F0, 0);
+                SpriteSetObjMode(&sUnknown_202F1F0, 0);
+                SpriteSetMosaic(&sUnknown_202F1F0, 0);
+                SpriteSetBpp(&sUnknown_202F1F0, 0);
+                SpriteSetShape(&sUnknown_202F1F0, 1);
+                SpriteSetTileNum(&sUnknown_202F1F0, 0x3F0);
+                SpriteSetPriority(&sUnknown_202F1F0, 0);
+                SpriteSetPalNum(&sUnknown_202F1F0, 15);
+                SpriteSetY(&sUnknown_202F1F0, 120);
+                SpriteSetMatrixNum(&sUnknown_202F1F0, 0);
+                SpriteSetSize(&sUnknown_202F1F0, 0);
+                SpriteSetX(&sUnknown_202F1F0, 112);
 
                 AddSprite(&sUnknown_202F1F0, 0x100, NULL, NULL);
             }
@@ -1081,39 +1059,20 @@ static void CreateMessageLogArrow(bool8 upArrow, s32 y)
 {
     struct UnkTextStruct1 *unkStr = &gUnknown_2027370[0];
     if (!(gUnknown_202EDCC & 8)) {
-        u32 matrixNum, xSprite, mask, ySprite, shape, yMask;
-
-        sMessageLogArrowSpriteOAM.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-        sMessageLogArrowSpriteOAM.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-        sMessageLogArrowSpriteOAM.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-        sMessageLogArrowSpriteOAM.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-        sMessageLogArrowSpriteOAM.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-        matrixNum = (upArrow != FALSE) ? (16) : 0;
-        // You may be thinking what is this empty loop doing here, but the better question is: Why do these unholy sprite macros exist?
-        do {} while (0);
-        matrixNum <<= 9;
-        sMessageLogArrowSpriteOAM.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-        sMessageLogArrowSpriteOAM.attrib2 |= matrixNum;
-
-        mask = 0xF; // ~SPRITEOAM_MASK_UNK6_4
-        yMask = SPRITEOAM_MAX_UNK6_4;
-        ySprite = (yMask & (unkStr->unk2 * 8 + y)) << 4;
-        sMessageLogArrowSpriteOAM.unk6 &= mask;
-        sMessageLogArrowSpriteOAM.unk6 |= ySprite;
-
-        xSprite = SPRITEOAM_MAX_X & ((unkStr->unk0 * 8) + 92);
-        sMessageLogArrowSpriteOAM.attrib2 &= ~SPRITEOAM_MASK_X;
-        sMessageLogArrowSpriteOAM.attrib2 |= xSprite;
-
-        shape = 1;
-        shape <<= SPRITEOAM_SHIFT_SHAPE;
-        sMessageLogArrowSpriteOAM.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-        sMessageLogArrowSpriteOAM.attrib1 |= shape;
-
-        sMessageLogArrowSpriteOAM.attrib2 &= ~SPRITEOAM_MASK_SIZE;
-
-        sMessageLogArrowSpriteOAM.attrib3 = 0xF3F0;
+        SpriteSetAffine1(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetAffine2(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetObjMode(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetMosaic(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetBpp(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetMatrixNum(&sMessageLogArrowSpriteOAM, (upArrow != FALSE) ? (16) : 0);
+        SpriteSetPalNum(&sMessageLogArrowSpriteOAM, 15);
+        SpriteSetY(&sMessageLogArrowSpriteOAM, (unkStr->unk2 * 8) + y);
+        SpriteSetX(&sMessageLogArrowSpriteOAM, (unkStr->unk0 * 8) + 92);
+        SpriteSetShape(&sMessageLogArrowSpriteOAM, 1);
+        SpriteSetSize(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetPriority(&sMessageLogArrowSpriteOAM, 0);
+        SpriteSetPalNum(&sMessageLogArrowSpriteOAM, 15);
+        SpriteSetTileNum(&sMessageLogArrowSpriteOAM, 0x3f0);
 
         AddSprite(&sMessageLogArrowSpriteOAM, 127, NULL, NULL);
     }

--- a/src/menu_input.c
+++ b/src/menu_input.c
@@ -603,74 +603,26 @@ void AddMenuCursorSprite(MenuInputStruct *param_1)
 
 void AddMenuCursorSprite_(MenuInputStruct *a0, u8 *a1)
 {
-    SpriteOAM sp = {};
-    SpriteOAM* ptr;
-    s32 value;
-    s32 r0;
-    s32 r1;
-    s32 r2;
-    s32 r5;
+    struct SpriteOAM sp = {0};
 
     if (a0->unk1A > 0) {
         UpdateMenuCursorSpriteCoords(a0);
 
         if (!(a0->unk24 & 8)) {
-            #ifdef NONMATCHING // SpriteOAM memes https://decomp.me/scratch/T9aXl
-            u32 tmp, tmp2;
-            #else
-            register u32 tmp asm("r0"), tmp2 asm("r1");
-            #endif
-
-            tmp = sp.attrib1;
-            sp.attrib1 = tmp & ~SPRITEOAM_MASK_AFFINEMODE1;
-            sp.attrib1 = sp.attrib1;
-
-            tmp2 = sp.attrib1;
-            sp.attrib1 = tmp2 & ~SPRITEOAM_MASK_AFFINEMODE2;
-            sp.attrib1 = sp.attrib1;
-
-            tmp2 = sp.attrib1;
-            sp.attrib1 = tmp2 & ~SPRITEOAM_MASK_OBJMODE;
-            sp.attrib1 = sp.attrib1;
-
-            tmp2 = sp.attrib1;
-            sp.attrib1 = tmp2 & ~SPRITEOAM_MASK_MOSAIC;
-            sp.attrib1 = sp.attrib1;
-
-            tmp2 = sp.attrib1;
-            sp.attrib1 = tmp2 & ~SPRITEOAM_MASK_BPP;
-            sp.attrib1 = sp.attrib1;
-
-            tmp2 = sp.attrib1;
-            sp.attrib1 = tmp2 & ~SPRITEOAM_MASK_SHAPE;
-            sp.attrib1 = sp.attrib1;
-
-            ptr = &sp;
-
-            r2 = 0x3F4 << SPRITEOAM_SHIFT_TILENUM;
-            ptr->attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-            ptr->attrib3 |= r2;
-
-            ptr->attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-
-            r5 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-            r1 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-            ptr->attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-            ptr->attrib3 |= r1;
-
-            ptr->unk6 &= ~SPRITEOAM_MASK_UNK6_0;
-            ptr->unk6 &= ~SPRITEOAM_MASK_UNK6_1;
-
-            r0 = a0->unk8.x;
-            r0 &= SPRITEOAM_MAX_X;
-            ptr->attrib2 = r0;
-
-            value = a0->unk8.y + 1;
-            value &= SPRITEOAM_MAX_UNK6_4;
-            value <<= SPRITEOAM_SHIFT_UNK6_4;
-            ptr->unk6 &= r5;
-            ptr->unk6 |= value;
+            SpriteSetAffine1(&sp, 0);
+            SpriteSetAffine2(&sp, 0);
+            SpriteSetObjMode(&sp, 0);
+            SpriteSetMosaic(&sp, 0);
+            SpriteSetBpp(&sp, 0);
+            SpriteSetShape(&sp, 0);
+            SpriteSetSize(&sp, 0);
+            SpriteSetTileNum(&sp, 0x3F4);
+            SpriteSetPriority(&sp, 0);
+            SpriteSetPalNum(&sp, 15);
+            SpriteSetUnk6_0(&sp, 0);
+            SpriteSetUnk6_1(&sp, 0);
+            SpriteSetX_MatrixNumSize0(&sp, a0->unk8.x);
+            SpriteSetY(&sp, a0->unk8.y + 1);
 
             AddSprite(&sp, 0xFF, 0, 0);
         }
@@ -689,197 +641,64 @@ void nullsub_34(MenuInputStructSub *a0, s32 a1)
 
 static void sub_801332C(DungeonPos *a0)
 {
-    SpriteOAM sp = {};
-    SpriteOAM* ptr;
-    #ifdef NONMATCHING // SpriteOAM memes https://decomp.me/scratch/zeLxS
-    u32 r0, r1, r2;
-    #else
-    register u32 r0 asm("r0");
-    register u32 r1 asm("r1");
-    register u32 r2 asm("r2");
-    #endif
-    u32 r3;
-    u32 r5;
-    u32 r6;
+    struct SpriteOAM sp = {0};
 
-    r1 = sp.attrib1;
-    sp.attrib1 = r1 & ~SPRITEOAM_MASK_AFFINEMODE1;
-    sp.attrib1 = sp.attrib1;
-
-    r2 = sp.attrib1;
-    sp.attrib1 = r2 & ~SPRITEOAM_MASK_AFFINEMODE2;
-    sp.attrib1 = sp.attrib1;
-
-    r5 = 1 << SPRITEOAM_SHIFT_OBJMODE;
-    r2 = sp.attrib1;
-    sp.attrib1 = r2 & ~SPRITEOAM_MASK_OBJMODE;
-    sp.attrib1 = sp.attrib1 | r5;
-
-    r2 = sp.attrib1;
-    sp.attrib1 = r2 & ~SPRITEOAM_MASK_MOSAIC;
-    sp.attrib1 = sp.attrib1;
-
-    r2 = sp.attrib1;
-    sp.attrib1 = r2 & ~SPRITEOAM_MASK_BPP;
-    sp.attrib1 = sp.attrib1;
-
-    r2 = sp.attrib1;
-    sp.attrib1 = r2 & ~SPRITEOAM_MASK_SHAPE;
-    sp.attrib1 = sp.attrib1;
-
-    ptr = &sp;
-
-    r3 = 0x3F5 << SPRITEOAM_SHIFT_TILENUM;
-    ptr->attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-    ptr->attrib3 |= r3;
-
-    ptr->attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-
-    r6 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-    r2 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-    ptr->attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-    ptr->attrib3 |= r2;
-
-    ptr->unk6 &= ~SPRITEOAM_MASK_UNK6_0;
-    ptr->unk6 &= ~SPRITEOAM_MASK_UNK6_1;
-
-    r1 = a0->x;
-    r1 &= SPRITEOAM_MAX_X;
-    ptr->attrib2 = r1;
-
-    r0 = a0->y + 1;
-    r0 &= SPRITEOAM_MAX_UNK6_4;
-    r0 <<= SPRITEOAM_SHIFT_UNK6_4;
-    ptr->unk6 &= r6;
-    ptr->unk6 |= r0;
+    SpriteSetAffine1(&sp, 0);
+    SpriteSetAffine2(&sp, 0);
+    SpriteSetObjMode(&sp, 1);
+    SpriteSetMosaic(&sp, 0);
+    SpriteSetBpp(&sp, 0);
+    SpriteSetShape(&sp, 0);
+    SpriteSetSize(&sp, 0);
+    SpriteSetTileNum(&sp, 0x3F5);
+    SpriteSetPriority(&sp, 0);
+    SpriteSetPalNum(&sp, 15);
+    SpriteSetUnk6_0(&sp, 0);
+    SpriteSetUnk6_1(&sp, 0);
+    SpriteSetX_MatrixNumSize0(&sp, a0->x);
+    SpriteSetY(&sp, a0->y + 1);
 
     AddSprite(&sp, 0xFF, NULL, NULL);
 }
 
 static void sub_8013470(MenuInputStruct *a0)
 {
-    SpriteOAM sp = {};
-    #ifdef NONMATCHING // SpriteOAM memes https://decomp.me/scratch/70Ieb
-    SpriteOAM *ptr;
-    u32 r0, r1, r5;
-    #else
-    register SpriteOAM *ptr asm("r3");
-    register u32 r0 asm("r0");
-    register u32 r1 asm("r1");
-    register u32 r5 asm("r5");
-    #endif
-    u32 r2;
+    struct SpriteOAM sp = {0};
 
     if (a0->unkC != 0) {
         if (a0->unk1E != 0) {
-            r0 = sp.attrib1;
-            sp.attrib1 = r0 & ~SPRITEOAM_MASK_AFFINEMODE1;
-            sp.attrib1 = sp.attrib1;
-
-            r1 = sp.attrib1;
-            sp.attrib1 = r1 & ~SPRITEOAM_MASK_AFFINEMODE2;
-            sp.attrib1 = sp.attrib1;
-
-            r1 = sp.attrib1;
-            sp.attrib1 = r1 & (u16)~SPRITEOAM_MASK_OBJMODE;
-            sp.attrib1 = sp.attrib1;
-
-            r1 = sp.attrib1;
-            sp.attrib1 = r1 & ~SPRITEOAM_MASK_MOSAIC;
-            sp.attrib1 = sp.attrib1;
-
-            r1 = sp.attrib1;
-            sp.attrib1 = r1 & ~SPRITEOAM_MASK_BPP;
-            sp.attrib1 = sp.attrib1;
-
-            r1 = sp.attrib1;
-            sp.attrib1 = r1 & ~SPRITEOAM_MASK_SHAPE;
-            sp.attrib1 = sp.attrib1;
-
-            ptr = &sp;
-
-            r2 = 0x3F2 << SPRITEOAM_SHIFT_TILENUM;
-            r1 = ptr->attrib3;
-            r0 = r1 & (u16)~SPRITEOAM_MASK_TILENUM;
-            r0 |= r2;
-
-            r0 &= (u16)~SPRITEOAM_MASK_PRIORITY;
-
-            r5 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-            r1 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-            r0 &= (u16)~SPRITEOAM_MASK_PALETTENUM;
-            r0 |= r1;
-            ptr->attrib3 = r0;
-
-            r0 = ptr->unk6;
-            r1 = r0 & (u16)~SPRITEOAM_MASK_UNK6_0;
-            r1 &= (u16)~SPRITEOAM_MASK_UNK6_1;
-
-            r0 = a0->unkC;
-            r0 &= SPRITEOAM_MAX_X;
-            ptr->attrib2 = r0;
-
-            r0 = a0->unkE;
-            r0 &= SPRITEOAM_MAX_UNK6_4;
-            r0 <<= SPRITEOAM_SHIFT_UNK6_4;
-            r1 &= r5;
-            r1 |= r0;
-            ptr->unk6 = r1;
+            SpriteSetAffine1(&sp, 0);
+            SpriteSetAffine2(&sp, 0);
+            SpriteSetObjMode(&sp, 0);
+            SpriteSetMosaic(&sp, 0);
+            SpriteSetBpp(&sp, 0);
+            SpriteSetShape(&sp, 0);
+            SpriteSetSize(&sp, 0);
+            SpriteSetTileNum(&sp, 0x3F2);
+            SpriteSetPriority(&sp, 0);
+            SpriteSetPalNum(&sp, 15);
+            SpriteSetUnk6_0(&sp, 0);
+            SpriteSetUnk6_1(&sp, 0);
+            SpriteSetX_MatrixNumSize0(&sp, a0->unkC);
+            SpriteSetY(&sp, a0->unkE);
 
             AddSprite(&sp, 0xFF, NULL, NULL);
         }
         if (a0->unk20 != 0 && a0->unk20 != a0->unk1E + 1) {
-            r0 = sp.attrib1;
-            sp.attrib1 = r0 & ~SPRITEOAM_MASK_AFFINEMODE1;
-            sp.attrib1 = sp.attrib1;
-
-            sp.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-            sp.attrib1 = sp.attrib1;
-
-            sp.attrib1 &= (u16)~SPRITEOAM_MASK_OBJMODE;
-            sp.attrib1 = sp.attrib1;
-
-            sp.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-            sp.attrib1 = sp.attrib1;
-
-            sp.attrib1 &= ~SPRITEOAM_MASK_BPP;
-            sp.attrib1 = sp.attrib1;
-
-            sp.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-            sp.attrib1 = sp.attrib1;
-
-            ptr = &sp;
-
-            r2 = 0x3F3 << SPRITEOAM_SHIFT_TILENUM;
-            r1 = ptr->attrib3;
-            r0 = r1 & (u16)~SPRITEOAM_MASK_TILENUM;
-            r0 |= r2;
-
-            r0 &= (u16)~SPRITEOAM_MASK_PRIORITY;
-
-            r5 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-            r1 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-            r0 &= (u16)~SPRITEOAM_MASK_PALETTENUM;
-            r0 |= r1;
-            ptr->attrib3 = r0;
-
-            r0 = ptr->unk6;
-            r1 = r0 & (u16)~SPRITEOAM_MASK_UNK6_0;
-            r1 &= (u16)~SPRITEOAM_MASK_UNK6_1;
-
-            r0 = a0->unkC + 10;
-            r0 &= SPRITEOAM_MAX_X;
-            ptr->attrib2 = r0;
-
-            r0 = a0->unkE;
-            r0 &= SPRITEOAM_MAX_UNK6_4;
-            r0 <<= SPRITEOAM_SHIFT_UNK6_4;
-            r1 &= r5;
-            r1 |= r0;
-            ptr->unk6 = r1;
+            SpriteSetAffine1(&sp, 0);
+            SpriteSetAffine2(&sp, 0);
+            SpriteSetObjMode(&sp, 0);
+            SpriteSetMosaic(&sp, 0);
+            SpriteSetBpp(&sp, 0);
+            SpriteSetShape(&sp, 0);
+            SpriteSetSize(&sp, 0);
+            SpriteSetTileNum(&sp, 0x3F3);
+            SpriteSetPriority(&sp, 0);
+            SpriteSetPalNum(&sp, 15);
+            SpriteSetUnk6_0(&sp, 0);
+            SpriteSetUnk6_1(&sp, 0);
+            SpriteSetX_MatrixNumSize0(&sp, a0->unkC + 10);
+            SpriteSetY(&sp, a0->unkE);
 
             AddSprite(&sp, 0xFF, NULL, NULL);
         }
@@ -1196,48 +1015,21 @@ void sub_8013A7C(MenuInputStruct *param_1)
 
 void sub_8013AA0(unkStructFor8013AA0 *a0)
 {
-    s32 r1;
-    s32 test;
-    s32 r3;
-    s32 r4;
-    s32 test2;
-    s16 earlyF;
     s32 sp[10];
 
-    a0->unk28.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-    a0->unk28.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-    a0->unk28.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-    a0->unk28.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-    a0->unk28.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-    r1 = 1 << SPRITEOAM_SHIFT_SHAPE;
-    a0->unk28.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-    a0->unk28.attrib1 |= r1;
-
-    test = 16 << SPRITEOAM_SHIFT_MATRIXNUM;
-    a0->unk28.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-    a0->unk28.attrib2 |= test;
-
-    a0->unk28.attrib2 &= ~SPRITEOAM_MASK_SIZE;
-
-    r3 = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-    a0->unk28.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-    a0->unk28.attrib3 |= r3;
-
-    a0->unk28.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-
-    earlyF = (s16)~SPRITEOAM_MASK_UNK6_4;
-
-    r4 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-    a0->unk28.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-    a0->unk28.attrib3 |= r4;
-
-    a0->unk28.attrib2 &= ~SPRITEOAM_MASK_X;
-    a0->unk28.attrib2 |= DISPLAY_WIDTH;
-
-    test2 = DISPLAY_WIDTH << SPRITEOAM_SHIFT_UNK6_4;
-    a0->unk28.unk6 &= earlyF;
-    a0->unk28.unk6 |= test2;
+    SpriteSetAffine1(&a0->unk28, 0);
+    SpriteSetAffine2(&a0->unk28, 0);
+    SpriteSetObjMode(&a0->unk28, 0);
+    SpriteSetMosaic(&a0->unk28, 0);
+    SpriteSetBpp(&a0->unk28, 0);
+    SpriteSetShape(&a0->unk28, 1);
+    SpriteSetMatrixNum(&a0->unk28, 16);
+    SpriteSetSize(&a0->unk28, 0);
+    SpriteSetTileNum(&a0->unk28, 0x3F0);
+    SpriteSetPriority(&a0->unk28, 0);
+    SpriteSetPalNum(&a0->unk28, 15);
+    SpriteSetX(&a0->unk28, DISPLAY_WIDTH);
+    SpriteSetY(&a0->unk28, DISPLAY_WIDTH);
 
     a0->unk26 = 0;
 
@@ -1265,24 +1057,12 @@ u32 sub_8013BBC(unkStructFor8013AA0 *a0)
     sub_8013D10(a0);
 
     if (a0->unk26 & 8) {
-        {
-            s32 temp = 16 << SPRITEOAM_SHIFT_MATRIXNUM;
-            a0->unk28.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-            a0->unk28.attrib2 |= temp;
-        }
+        SpriteSetMatrixNum(&a0->unk28, 16);
         AddSprite(&a0->unk28, 0x100, NULL, NULL);
 
-        a0->unk28.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-        {
-            u32 temp = a0->unk28.unk6;
-            s32 max = SPRITEOAM_MAX_UNK6_4;
-            temp >>= SPRITEOAM_SHIFT_UNK6_4;
-            temp += 16;
-            temp &= max;
-            temp <<= SPRITEOAM_SHIFT_UNK6_4;
-            a0->unk28.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-            a0->unk28.unk6 |= temp;
-        }
+        SpriteSetMatrixNum(&a0->unk28, 0);
+        SpriteAddY(&a0->unk28, 16);
+
         AddSprite(&a0->unk28, 0x100, NULL, NULL);
     }
 
@@ -1326,6 +1106,7 @@ void sub_8013C68(unkStructFor8013AA0 *a0)
 
 void sub_8013D10(unkStructFor8013AA0 *a0)
 {
+    s32 x, y;
     u8 uVar4;
     UnkTextStruct1 *ptr;
 
@@ -1347,21 +1128,11 @@ void sub_8013D10(unkStructFor8013AA0 *a0)
         a0->unk26 = 8;
     }
 
-    {
-        s32 temp = (a0->unk1C - ((a0->unk24 + 1) * 12) + (ptr->unk0 * 8)) - 3;
-        temp &= SPRITEOAM_MAX_X;
-        temp <<= SPRITEOAM_SHIFT_X;
-        a0->unk28.attrib2 &= ~SPRITEOAM_MASK_X;
-        a0->unk28.attrib2 |= temp;
-    } while (0);
+    x = (a0->unk1C - ((a0->unk24 + 1) * 12) + (ptr->unk0 * 8)) - 3;
+    SpriteSetX(&a0->unk28, x);
 
-    {
-        s32 temp = a0->unk20 + (ptr->unk2 * 8) - 7;
-        temp &= SPRITEOAM_MAX_UNK6_4;
-        temp <<= SPRITEOAM_SHIFT_UNK6_4;
-        a0->unk28.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-        a0->unk28.unk6 |= temp;
-    } while (0);
+    y = a0->unk20 + (ptr->unk2 * 8) - 7;
+    SpriteSetY(&a0->unk28, y);
 }
 
 static bool8 sub_8013DD0(unkStructFor8013AA0 *a0)

--- a/src/other_menus1.c
+++ b/src/other_menus1.c
@@ -330,70 +330,25 @@ static void sub_8037400(void)
 
 static void sub_80376CC(void)
 {
-#ifdef NONMATCHING // SpriteOAM memes
-    u32 r0;
-    u32 r2;
-#else
-    register u32 r0 asm("r0");
-    register u32 r2 asm("r2");
-#endif
-    u32 r1;
-    u32 r4;
-
-    r1 = sUnknown_203B35C->unkC.attrib1;
-    r0 = (u16)~SPRITEOAM_MASK_AFFINEMODE1;
-    r0 &= r1;
-
-    r0 &= (u16)~SPRITEOAM_MASK_AFFINEMODE2;
-
-    r0 &= (u16)~SPRITEOAM_MASK_OBJMODE;
-
-    r0 &= (u16)~SPRITEOAM_MASK_MOSAIC;
-
-    r0 &= (u16)~SPRITEOAM_MASK_BPP;
-
-    r2 = 1 << SPRITEOAM_SHIFT_SHAPE;
-    r0 &= (u16)~SPRITEOAM_MASK_SHAPE;
-    r0 |= r2;
-
-    sUnknown_203B35C->unkC.attrib1 = r0;
-
-    r2 = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-    r1 = sUnknown_203B35C->unkC.attrib3;
-    r0 = (u16)~SPRITEOAM_MASK_TILENUM;
-    r0 &= r1;
-    r0 |= r2;
-
-    r0 &= (u16)~SPRITEOAM_MASK_PRIORITY;
-
-    r2 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-    r4 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-    r0 &= (u16)~SPRITEOAM_MASK_PALETTENUM;
-    r0 |= r4;
-
-    sUnknown_203B35C->unkC.attrib3 = r0;
-
-    r0 = 0; // Set x/matrixNum/size to 0
-    sUnknown_203B35C->unkC.attrib2 = r0;
-
-    r1 = 192 << SPRITEOAM_SHIFT_UNK6_4;
-    r0 = sUnknown_203B35C->unkC.unk6;
-    r2 &= r0;
-    r2 |= r1;
-    sUnknown_203B35C->unkC.unk6 = r2;
+    SpriteSetAffine1(&sUnknown_203B35C->unkC, 0);
+    SpriteSetAffine2(&sUnknown_203B35C->unkC, 0);
+    SpriteSetObjMode(&sUnknown_203B35C->unkC, 0);
+    SpriteSetMosaic(&sUnknown_203B35C->unkC, 0);
+    SpriteSetBpp(&sUnknown_203B35C->unkC, 0);
+    SpriteSetShape(&sUnknown_203B35C->unkC, 1);
+    SpriteSetTileNum(&sUnknown_203B35C->unkC, 0x3F0);
+    SpriteSetPriority(&sUnknown_203B35C->unkC, 0);
+    SpriteSetPalNum(&sUnknown_203B35C->unkC, 15);
+    SpriteSetX(&sUnknown_203B35C->unkC, 0);
+    SpriteSetMatrixNum(&sUnknown_203B35C->unkC, 0);
+    SpriteSetSize(&sUnknown_203B35C->unkC, 0);
+    SpriteSetY(&sUnknown_203B35C->unkC, 192);
 }
 
 static void sub_8037748(void)
 {
-    u16 temp2;
-
-    sUnknown_203B35C->unkC.attrib2 &= ~SPRITEOAM_MASK_X; // Clear x
-    sUnknown_203B35C->unkC.attrib2 |= 112; // Set x to 112
-
-    temp2 = 104 << SPRITEOAM_SHIFT_UNK6_4;
-    sUnknown_203B35C->unkC.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-    sUnknown_203B35C->unkC.unk6 |= temp2;
+    SpriteSetX(&sUnknown_203B35C->unkC, 112);
+    SpriteSetY(&sUnknown_203B35C->unkC, 104);
 
     if ((sUnknown_203B35C->unk14 & 8) != 0)
       AddSprite(&sUnknown_203B35C->unkC, 0x100, NULL, NULL);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1410,52 +1410,21 @@ void InitShadowSprites(s32 param_1, s32 param_2)
     CloseFile(file);
 
     for (spriteIndex = 0; spriteIndex < 3; spriteIndex++) {
-        u32 objMode, shape, size, tileNum, priority;
-
         SpriteOAM *sprite = &gShadowSprites[spriteIndex];
 
-        sprite->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-        sprite->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-
-        objMode = 0;
-        objMode &= SPRITEOAM_MAX_OBJMODE;
-        objMode <<= SPRITEOAM_SHIFT_OBJMODE;
-        sprite->attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-        sprite->attrib1 |= objMode;
-
-        sprite->attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-        sprite->attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-        shape = gShadowSpriteSizeFlags_8107698[spriteIndex].shape;
-        shape &= SPRITEOAM_MAX_SHAPE;
-        shape <<= SPRITEOAM_SHIFT_SHAPE;
-        sprite->attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-        sprite->attrib1 |= shape;
-
-        sprite->attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-
-        size = gShadowSpriteSizeFlags_8107698[spriteIndex].size;
-        size &= SPRITEOAM_MAX_SIZE;
-        size <<= SPRITEOAM_SHIFT_SIZE;
-        sprite->attrib2 &= ~SPRITEOAM_MASK_SIZE;
-        sprite->attrib2 |= size;
-
-        tileNum = gShadowSpriteSizeFlags_8107698[spriteIndex].tileNum + param_1;
-        tileNum &= SPRITEOAM_MAX_TILENUM;
-        tileNum <<= SPRITEOAM_SHIFT_TILENUM;
-        sprite->attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-        sprite->attrib3 |= tileNum;
-
-        priority = param_2;
-        priority &= SPRITEOAM_MAX_PRIORITY;
-        priority <<= SPRITEOAM_SHIFT_PRIORITY;
-        sprite->attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-        sprite->attrib3 |= priority;
-
-        sprite->attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-
-        sprite->unk6 &= ~SPRITEOAM_MASK_UNK6_0;
-        sprite->unk6 &= ~SPRITEOAM_MASK_UNK6_1;
+        SpriteSetAffine1(sprite, 0);
+        SpriteSetAffine2(sprite, 0);
+        SpriteSetObjMode(sprite, 0);
+        SpriteSetMosaic(sprite, 0);
+        SpriteSetBpp(sprite, 0);
+        SpriteSetShape(sprite, gShadowSpriteSizeFlags_8107698[spriteIndex].shape);
+        SpriteSetMatrixNum(sprite, 0);
+        SpriteSetSize(sprite, gShadowSpriteSizeFlags_8107698[spriteIndex].size);
+        SpriteSetTileNum(sprite, gShadowSpriteSizeFlags_8107698[spriteIndex].tileNum + param_1);
+        SpriteSetPriority(sprite, param_2);
+        SpriteSetPalNum(sprite, 0);
+        SpriteSetUnk6_0(sprite, 0);
+        SpriteSetUnk6_1(sprite, 0);
     }
 }
 
@@ -1466,24 +1435,16 @@ bool8 AddShadowSprite(s16 species, s16* a2, s16* a3)
     if (species != MONSTER_DIGLETT && species != MONSTER_DUGTRIO) {
         s32 shadowSize = GetShadowSize(species);
         s32 x, y;
-        SpriteOAM* spr;
 
         x = a2[0] + a3[8];
         y = a2[1] + a3[9];
         x += gUnknown_81076C4[shadowSize];
         y -= 4;
 
-        x &= SPRITEOAM_MAX_X;
-        x <<= SPRITEOAM_SHIFT_X;
-        spr = &gShadowSprites[shadowSize];
-        spr->attrib2 &= ~SPRITEOAM_MASK_X;
-        spr->attrib2 |= x;
+        SpriteSetX(&gShadowSprites[shadowSize], x);
+        SpriteSetY(&gShadowSprites[shadowSize], y);
 
-        y &= SPRITEOAM_MAX_UNK6_4;
-        y <<= SPRITEOAM_SHIFT_UNK6_4;
-        spr->unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-        spr->unk6 |= y;
-        AddSprite(spr, 0, NULL, NULL);
+        AddSprite(&gShadowSprites[shadowSize], 0, NULL, NULL);
     }
 
     return TRUE;

--- a/src/rescue_password_menu.c
+++ b/src/rescue_password_menu.c
@@ -679,67 +679,29 @@ u32 sub_8039068(u32 mailMode, u8 *passwordBuffer, unkStruct_203B480 *param_3)
 
 void sub_8039174(void)
 {
-    struct SpriteOAM* spr;
-    s16 earlyF;
+    SpriteSetAffine1(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetAffine2(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetObjMode(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetMosaic(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetBpp(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetShape(&gRescuePasswordMenu->unk208, 1);
+    SpriteSetTileNum(&gRescuePasswordMenu->unk208, 0x3F0);
+    SpriteSetPriority(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetPalNum(&gRescuePasswordMenu->unk208, 15);
+    SpriteSetMatrixNum(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetSize(&gRescuePasswordMenu->unk208, 0);
 
-    spr = &gRescuePasswordMenu->unk208;
-
-    spr->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-    spr->attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-    spr->attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-    spr->attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-    spr->attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-    {
-        s32 temp = 1 << SPRITEOAM_SHIFT_SHAPE;
-        spr->attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-        spr->attrib1 |= temp;
-    } while(0);
-
-    {
-        s32 temp = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-        spr->attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-        spr->attrib3 |= temp;
-    } while(0);
-
-    spr->attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-
-    earlyF = (s16)~SPRITEOAM_MASK_UNK6_4;
-
-    {
-        s32 temp = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-        spr->attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-        spr->attrib3 |= temp;
-    } while(0);
-
-    {
-        s32 temp = 0;
-        spr->attrib2 = temp;
-    } while(0);
-
-    {
-        s32 temp = 192 << SPRITEOAM_SHIFT_UNK6_4;
-        spr->unk6 &= earlyF;
-        spr->unk6 |= temp;
-    } while(0);
+    SpriteSetX(&gRescuePasswordMenu->unk208, 0);
+    SpriteSetY(&gRescuePasswordMenu->unk208, 192);
 }
 
 void sub_80391F8(void)
 {
-    SpriteOAM *spr;
-    u32 val;
-
-    spr = &gRescuePasswordMenu->unk208;
-
-    spr->attrib2 &= ~SPRITEOAM_MASK_X;
-    spr->attrib2 |= 112;
-
-    val = 112 << SPRITEOAM_SHIFT_UNK6_4;
-    spr->unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-    spr->unk6 |= val;
+    SpriteSetX(&gRescuePasswordMenu->unk208, 112);
+    SpriteSetY(&gRescuePasswordMenu->unk208, 112);
 
     if (gRescuePasswordMenu->unk210 & 8)
-        AddSprite(spr, 0x100, NULL, NULL);
+        AddSprite(&gRescuePasswordMenu->unk208, 0x100, NULL, NULL);
 
     DrawDialogueBoxString();
     gRescuePasswordMenu->unk210++;

--- a/src/save_menu.c
+++ b/src/save_menu.c
@@ -266,61 +266,24 @@ s32 UpdateSaveMenu(void)
 
 void sub_8038830(void)
 {
-#ifdef NONMATCHING // SpriteOAM memes
-    u32 r0;
-    u32 r2;
-#else
-    register u32 r0 asm("r0");
-    register u32 r2 asm("r2");
-#endif
-    u32 r1;
-    u32 r4;
-    u32 r5;
-    SpriteOAM *sprite;
+    SpriteSetAffine1(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetAffine2(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetObjMode(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetMosaic(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetBpp(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetShape(&sUnknown_203B364->unk1A8, 1);
 
-    r5 = 0;
-    sprite = &sUnknown_203B364->unk1A8;
+    SpriteSetTileNum(&sUnknown_203B364->unk1A8, 0x3F0);
+    SpriteSetPriority(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetPalNum(&sUnknown_203B364->unk1A8, 15);
 
-    r1 = sprite->attrib1;
-    r0 = (u16)~SPRITEOAM_MASK_AFFINEMODE1;
-    r0 &= r1;
+    SpriteSetMatrixNum(&sUnknown_203B364->unk1A8, 0);
+    SpriteSetSize(&sUnknown_203B364->unk1A8, 0);
 
-    r0 &= (u16)~SPRITEOAM_MASK_AFFINEMODE2;
+    SpriteSetX(&sUnknown_203B364->unk1A8, 112);
+    SpriteSetY(&sUnknown_203B364->unk1A8, 104);
 
-    r0 &= (u16)~SPRITEOAM_MASK_OBJMODE;
-
-    r0 &= (u16)~SPRITEOAM_MASK_MOSAIC;
-
-    r0 &= (u16)~SPRITEOAM_MASK_BPP;
-
-    r2 = 1 << SPRITEOAM_SHIFT_SHAPE;
-    r0 &= (u16)~SPRITEOAM_MASK_SHAPE;
-    r0 |= r2;
-    sprite->attrib1 = r0;
-
-    r2 = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-    r1 = sprite->attrib3;
-    r0 = (u16)~SPRITEOAM_MASK_TILENUM;
-    r0 &= r1;
-    r0 |= r2;
-
-    r0 &= (u16)~SPRITEOAM_MASK_PRIORITY;
-
-    r2 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-    r4 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-    r0 &= (u16)~SPRITEOAM_MASK_PALETTENUM;
-    r0 |= r4;
-    sprite->attrib3 = r0;
-
-    sprite->attrib2 = 112; // Set x to 112. Set matrixNum/size to 0
-
-    r1 = 104 << SPRITEOAM_SHIFT_UNK6_4;
-    r2 &= sprite->unk6;
-    r2 |= r1;
-    sprite->unk6 = r2;
-
-    sUnknown_203B364->unk1B0 = r5;
+    sUnknown_203B364->unk1B0 = 0;
     ResetSprites(FALSE);
 }
 

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -180,7 +180,7 @@ void AddAxSprite(ax_pose *a0, axdata1 *a1, UnkSpriteMem *a2, unkStruct_2039DB0 *
     } sp;
     SpriteOAM *sprite;
     s32 spriteId;
-    s32 pos; // Has to be used for both x and pos to match
+    s32 pos; // Has to be used for both x and y to match
     struct UnkStackFor8004EA8 *spPtr;
 
     if (a2 != NULL)

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -218,14 +218,10 @@ void AddAxSprite(ax_pose *a0, axdata1 *a1, UnkSpriteMem *a2, unkStruct_2039DB0 *
     }
     else {
         // Animations add to existing tileNum
-        s32 tileNum = sprite->attrib3;
-        tileNum &= SPRITEOAM_MAX_TILENUM;
-        tileNum >>= SPRITEOAM_SHIFT_TILENUM;
-
-        SpriteSetTileNum(sprite, tileNum + a1->vramTileOrMaybeAnimTimer);
+        SpriteAddTileNum(sprite, a1->vramTileOrMaybeAnimTimer);
     }
 
-    pos = ((sprite->attrib2 >> SPRITEOAM_SHIFT_X) & SPRITEOAM_MAX_X) ;
+    pos = SpriteGetX(sprite);
     pos += a1->pos.x - 0x100;
 
     if (pos < -64)
@@ -235,7 +231,7 @@ void AddAxSprite(ax_pose *a0, axdata1 *a1, UnkSpriteMem *a2, unkStruct_2039DB0 *
 
     SpriteSetX(sprite, pos);
 
-    pos = ((sprite->unk6 >> SPRITEOAM_SHIFT_WORKING_Y) & SPRITEOAM_MAX_WORKING_Y);
+    pos = SpriteGetY(sprite);
     pos += a1->pos.y - 0x200;
     if (pos < -64)
         return;
@@ -245,7 +241,7 @@ void AddAxSprite(ax_pose *a0, axdata1 *a1, UnkSpriteMem *a2, unkStruct_2039DB0 *
     SpriteSetOamY(sprite, pos);
 
     // Set paletteNum
-    if (!((sprite->unk6 >> SPRITEOAM_SHIFT_UNK6_1) & SPRITEOAM_MAX_UNK6_1)) {
+    if (!SpriteGetUnk6_1(sprite)) {
         SpriteSetPalNum(sprite, a1->paletteNum);
     }
 

--- a/src/string_format.c
+++ b/src/string_format.c
@@ -527,49 +527,25 @@ void DrawDialogueBoxString(void)
                 if (!buttonPress) {
                     sArrowFrames++;
                     if (!(sUnknownTextFlags & 0x2) && sArrowFrames & 8) {
-                        u32 shape, tileNum, palNum, pal;
-
-                        sDialogueBoxArrowSprite.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE1;
-                        sDialogueBoxArrowSprite.attrib1 &= ~SPRITEOAM_MASK_AFFINEMODE2;
-                        sDialogueBoxArrowSprite.attrib1 &= ~SPRITEOAM_MASK_OBJMODE;
-                        sDialogueBoxArrowSprite.attrib1 &= ~SPRITEOAM_MASK_MOSAIC;
-                        sDialogueBoxArrowSprite.attrib1 &= ~SPRITEOAM_MASK_BPP;
-
-                        shape = 1;
-                        shape <<= SPRITEOAM_SHIFT_SHAPE;
-                        sDialogueBoxArrowSprite.attrib1 &= ~SPRITEOAM_MASK_SHAPE;
-                        sDialogueBoxArrowSprite.attrib1 |= shape;
-
-                        sDialogueBoxArrowSprite.attrib2 &= ~SPRITEOAM_MASK_MATRIXNUM;
-                        sDialogueBoxArrowSprite.attrib2 &= ~SPRITEOAM_MASK_SIZE;
-
-                        tileNum = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-                        sDialogueBoxArrowSprite.attrib3 &= ~SPRITEOAM_MASK_TILENUM;
-                        sDialogueBoxArrowSprite.attrib3 |= tileNum;
-
-                        sDialogueBoxArrowSprite.attrib3 &= ~SPRITEOAM_MASK_PRIORITY;
-
-                        pal = 15;
-                        palNum = (pal & SPRITEOAM_MAX_PALETTENUM) << SPRITEOAM_SHIFT_PALETTENUM;
-                        sDialogueBoxArrowSprite.attrib3 &= ~SPRITEOAM_MASK_PALETTENUM;
-                        sDialogueBoxArrowSprite.attrib3 |= palNum;
+                        SpriteSetAffine1(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetAffine2(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetObjMode(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetMosaic(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetBpp(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetShape(&sDialogueBoxArrowSprite, 1);
+                        SpriteSetMatrixNum(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetSize(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetTileNum(&sDialogueBoxArrowSprite, 0x3F0);
+                        SpriteSetPriority(&sDialogueBoxArrowSprite, 0);
+                        SpriteSetPalNum(&sDialogueBoxArrowSprite, 15);
 
                         if (sUnknownTextFlags & 0x10) {
-                            u32 var = (0x78 & SPRITEOAM_MAX_UNK6_4) << SPRITEOAM_SHIFT_UNK6_4;
-                            sDialogueBoxArrowSprite.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-                            sDialogueBoxArrowSprite.unk6 |= var;
-                            sDialogueBoxArrowSprite.attrib2 &= ~SPRITEOAM_MASK_X;
-                            sDialogueBoxArrowSprite.attrib2 |= (0x70 & SPRITEOAM_MAX_X) << SPRITEOAM_SHIFT_X;
+                            SpriteSetY(&sDialogueBoxArrowSprite, 120);
+                            SpriteSetX(&sDialogueBoxArrowSprite, 112);
                         }
                         else {
-                            s16 x;
-
-                            u32 var = ((gUnknown_202E748.unkA + 1) & SPRITEOAM_MAX_UNK6_4) << SPRITEOAM_SHIFT_UNK6_4;
-                            sDialogueBoxArrowSprite.unk6 &= ~SPRITEOAM_MASK_UNK6_4;
-                            sDialogueBoxArrowSprite.unk6 |= var;
-                            x = gUnknown_202E748.unk8;
-                            sDialogueBoxArrowSprite.attrib2 &= ~SPRITEOAM_MASK_X;
-                            sDialogueBoxArrowSprite.attrib2 |= (x & SPRITEOAM_MAX_X) << SPRITEOAM_SHIFT_X;
+                            SpriteSetY(&sDialogueBoxArrowSprite, gUnknown_202E748.unkA + 1);
+                            SpriteSetX(&sDialogueBoxArrowSprite, gUnknown_202E748.unk8);
                         }
 
                         AddSprite(&sDialogueBoxArrowSprite, 0x100, NULL, NULL);

--- a/src/unk_menu_203B360.c
+++ b/src/unk_menu_203B360.c
@@ -127,65 +127,25 @@ u32 sub_80383D4(void)
 
 void sub_8038440(void)
 {
-#ifdef NONMATCHING // SpriteOAM memes
-    u32 r0;
-    u32 r2;
-#else
-    register u32 r0 asm("r0");
-    register u32 r2 asm("r2");
-#endif
-    u32 r1;
-    u32 r4;
-    u32 r5;
-    SpriteOAM *sprite;
+    SpriteSetAffine1(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetAffine2(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetObjMode(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetMosaic(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetBpp(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetShape(&sUnknown_203B360->unk1A8, 1);
 
-    r5 = 0;
-    sprite = &sUnknown_203B360->unk1A8;
+    SpriteSetTileNum(&sUnknown_203B360->unk1A8, 0x3F0);
+    SpriteSetPriority(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetPalNum(&sUnknown_203B360->unk1A8, 15);
 
-    r1 = sprite->attrib1;
-    r0 = (u16)~SPRITEOAM_MASK_AFFINEMODE1;
-    r0 &= r1;
+    SpriteSetMatrixNum(&sUnknown_203B360->unk1A8, 0);
+    SpriteSetSize(&sUnknown_203B360->unk1A8, 0);
 
-    r0 &= (u16)~SPRITEOAM_MASK_AFFINEMODE2;
+    SpriteSetX(&sUnknown_203B360->unk1A8, 112);
+    SpriteSetY(&sUnknown_203B360->unk1A8, 112);
 
-    r0 &= (u16)~SPRITEOAM_MASK_OBJMODE;
-
-    r0 &= (u16)~SPRITEOAM_MASK_MOSAIC;
-
-    r0 &= (u16)~SPRITEOAM_MASK_BPP;
-
-    r2 = 1 << SPRITEOAM_SHIFT_SHAPE;
-    r0 &= (u16)~SPRITEOAM_MASK_SHAPE;
-    r0 |= r2;
-
-    sprite->attrib1 = r0;
-
-    r2 = 0x3F0 << SPRITEOAM_SHIFT_TILENUM;
-    r1 = sprite->attrib3;
-    r0 = (u16)~SPRITEOAM_MASK_TILENUM;
-    r0 &= r1;
-    r0 |= r2;
-
-    r0 &= (u16)~SPRITEOAM_MASK_PRIORITY;
-
-    r2 = (u16)~SPRITEOAM_MASK_UNK6_4;
-
-    r4 = 15 << SPRITEOAM_SHIFT_PALETTENUM;
-    r0 &= (u16)~SPRITEOAM_MASK_PALETTENUM;
-    r0 |= r4;
-
-    sprite->attrib3 = r0;
-
-    sprite->attrib2 = 112; // Set x to 112. Set matrixNum/size to 0
-
-    r1 = 112 << SPRITEOAM_SHIFT_UNK6_4;
-    r2 &= sprite->unk6;
-    r2 |= r1;
-    sprite->unk6 = r2;
-
-    sUnknown_203B360->unk1B0 = r5;
+    sUnknown_203B360->unk1B0 = 0;
 }
-
 
 void sub_80384D0(void)
 {


### PR DESCRIPTION
It's happened. All(or almost all) functions which were non-matching or using registers are finally matching, with easy to follow code. 
Note that these have to be macros(which is not ideal, but nothing can be done about it I guess), for this particular case static inlines **won't** work. 

What's interesting is these macros sometimes unroll to code like this `(&sp)->attribX &= ;` which generates different asm(and in this case that's the matching asm) than `sp.attribX &=`. 