### PR TITLE
Add flags union to Tile struct

### DIFF
--- a/include/structs/map.h
+++ b/include/structs/map.h
@@ -55,15 +55,18 @@ enum SpawnFlags
 #define VISIBILITY_FLAG_REVEALED 1 // When using Luminous Orb - whole layout is shown, but grayed-out
 #define VISIBILITY_FLAG_VISITED 2 // Tile was visited, show filled/white layout
 
-// size: 0x18
+union SpawnOrVisibilityFlags
+{
+    u16 spawn; // Tracks the kinds of entities which should be spawned on this tile. See: SpawnFlags
+    u16 visibility;
+};
+
+// size: 0x18 Red, 0x14 Blue
 typedef struct Tile
 {
-    // Uses the TerrainType bit flags.
-    /* 0x0 */ u16 terrainType;
-    u8 fill2[0x4 - 0x2];
-    u16 spawnOrVisibilityFlags; // Tracks the kinds of entities which should be spawned on this tile. See: SpawnFlags
-    u16 unk6;
-    u8 unk8;
+    /* 0x0 */ u16 terrainFlags; // Uses the TerrainType bit flags.
+    /* 0x4 */ union SpawnOrVisibilityFlags spawnOrVisibilityFlags;  // Because of padding this field takes 6 bytes on gba and only 2 on DS.
+    /* 0x8 */ u8 unk8;
     /* 0x9 */ u8 room;
     // Bitwise flags for whether Pokémon can move to an adjacent tile. Bits correspond to directions in direction.h.
     // Different sets of flags are used for Pokémon that can cross special terrain, corresponding to the CrossableTerrain enum.
@@ -92,10 +95,10 @@ typedef struct RoomData
 } RoomData;
 
 // Helper functions for main terrain types.
-static inline void SetTerrainType(Tile *tile, u32 terrainType)
+static inline void SetTerrainType(Tile *tile, u32 terrainFlags)
 {
-    tile->terrainType &= ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    tile->terrainType |= terrainType;
+    tile->terrainFlags &= ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    tile->terrainFlags |= terrainFlags;
 }
 
 static inline void SetTerrainNormal(Tile *tile)
@@ -115,7 +118,7 @@ static inline void SetTerrainWall(Tile *tile)
 
 static inline s32 GetTerrainType(const Tile *tile)
 {
-    return tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    return tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
 }
 
 

--- a/src/code_8066D04.c
+++ b/src/code_8066D04.c
@@ -316,7 +316,7 @@ void HandlePlaceItemAction(Entity *entity)
     }
     else {
         const Tile *tile = GetTile(entity->pos.x, entity->pos.y);
-        if ((tile->terrainType & TERRAIN_TYPE_STAIRS)) {
+        if ((tile->terrainFlags & TERRAIN_TYPE_STAIRS)) {
             LogMessageByIdWithPopupCheckUser(entity,gUnknown_80F8E04);
         }
         else if (GetTerrainType(tile) != TERRAIN_TYPE_NORMAL) {

--- a/src/code_8069E0C.c
+++ b/src/code_8069E0C.c
@@ -498,7 +498,7 @@ void sub_806B6C4(void)
             x++;
             if (x == DUNGEON_MAX_SIZE_X) {x = 0;}
 
-            if (GetTile(x, y)->spawnOrVisibilityFlags & 8) {
+            if (GetTile(x, y)->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_MONSTER) {
                 bool8 r6 = FALSE;
 
                 if (r8) {

--- a/src/code_806CD90.c
+++ b/src/code_806CD90.c
@@ -501,24 +501,19 @@ void DetermineAllMonsterShadow(void)
 
 u32 DetermineMonsterShadow(Entity *entity)
 {
-    const Tile *mapTile;
-    u32 shadowSize;
-    u16 terrainFlags;
-    EntityInfo *entityInfo;
+    const Tile *mapTile = GetTileAtEntitySafe(entity);
+    u16 terrainType = GetTerrainType(mapTile);
+    EntityInfo *entityInfo = GetEntInfo(entity);
+    u32 shadowSize = GetShadowSize(entityInfo->apparentID);
 
-    mapTile = GetTileAtEntitySafe(entity);
-    terrainFlags = mapTile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    entityInfo = GetEntInfo(entity);
-    shadowSize = GetShadowSize(entityInfo->apparentID);
-
-    if (terrainFlags == (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY))
+    if (terrainType == (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY))
         return 6;
 
-    if (terrainFlags == TERRAIN_TYPE_NORMAL) {
+    if (terrainType == TERRAIN_TYPE_NORMAL) {
         if (IsWaterTileset())
             shadowSize = gUnknown_8106EEF[shadowSize];
     }
-    else if (terrainFlags == TERRAIN_TYPE_SECONDARY && gDungeonWaterType[gDungeon->tileset] != DUNGEON_WATER_TYPE_LAVA)
+    else if (terrainType == TERRAIN_TYPE_SECONDARY && gDungeonWaterType[gDungeon->tileset] != DUNGEON_WATER_TYPE_LAVA)
         shadowSize = gUnknown_8106EEF[shadowSize];
 
     entityInfo->unk204 = shadowSize;

--- a/src/code_806CD90.c
+++ b/src/code_806CD90.c
@@ -503,22 +503,22 @@ u32 DetermineMonsterShadow(Entity *entity)
 {
     const Tile *mapTile;
     u32 shadowSize;
-    u16 terrainType;
+    u16 terrainFlags;
     EntityInfo *entityInfo;
 
     mapTile = GetTileAtEntitySafe(entity);
-    terrainType = mapTile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    terrainFlags = mapTile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
     entityInfo = GetEntInfo(entity);
     shadowSize = GetShadowSize(entityInfo->apparentID);
 
-    if (terrainType == (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY))
+    if (terrainFlags == (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY))
         return 6;
 
-    if (terrainType == TERRAIN_TYPE_NORMAL) {
+    if (terrainFlags == TERRAIN_TYPE_NORMAL) {
         if (IsWaterTileset())
             shadowSize = gUnknown_8106EEF[shadowSize];
     }
-    else if (terrainType == TERRAIN_TYPE_SECONDARY && gDungeonWaterType[gDungeon->tileset] != DUNGEON_WATER_TYPE_LAVA)
+    else if (terrainFlags == TERRAIN_TYPE_SECONDARY && gDungeonWaterType[gDungeon->tileset] != DUNGEON_WATER_TYPE_LAVA)
         shadowSize = gUnknown_8106EEF[shadowSize];
 
     entityInfo->unk204 = shadowSize;

--- a/src/code_8075708.c
+++ b/src/code_8075708.c
@@ -439,7 +439,7 @@ u32 sub_8075818(Entity *entity)
     {
         tile = GetTileAtEntitySafe(entity);
         if(IQSkillIsEnabled(entity, IQ_SUPER_MOBILE))
-            if(!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+            if(!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
                 return 1;
         subEntity = tile->object;
         if(subEntity != NULL)
@@ -483,7 +483,7 @@ flag_check:
                     {
                         if(!(entityInfo->heldItem.flags & ITEM_FLAG_EXISTS))
                         {
-                            if(!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+                            if(!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
                             {
                                 if(entityInfo->isNotTeamMember)
                                     break;
@@ -529,7 +529,7 @@ void sub_8075900(Entity *pokemon, u8 r1)
             {
                 if(!gDungeon->unk644.monsterHouseTriggered)
                 {
-                    if((GetTileAtEntitySafe(pokemon)->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE))
+                    if((GetTileAtEntitySafe(pokemon)->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE))
                     {
                         // It's a monster house!
                         LogMessageByIdWithPopupCheckUser(GetLeader(), gPtrItsaMonsterHouseMessage);

--- a/src/code_8077274_1.c
+++ b/src/code_8077274_1.c
@@ -100,7 +100,7 @@ void sub_807AB38(Entity *entity, bool8 forcedMonsterHouse)
 
     if (GetEntInfo(entity)->isNotTeamMember)
         return;
-    if (!(GetTileAtEntitySafe(entity)->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE))
+    if (!(GetTileAtEntitySafe(entity)->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE))
         return;
 
     if (gDungeon->unk644.monsterHouseTriggered)
@@ -137,7 +137,7 @@ void sub_807AB38(Entity *entity, bool8 forcedMonsterHouse)
         for (y = yStart; y < yEnd; y++) {
             for (x = xStart; x < xEnd; x++) {
                 Tile *tile = GetTileMut(x, y);
-                if (tile->monster == NULL && GetTerrainType(tile) == TERRAIN_TYPE_NORMAL && tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE && count < 100) {
+                if (tile->monster == NULL && GetTerrainType(tile) == TERRAIN_TYPE_NORMAL && tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE && count < 100) {
                     positions[count].x = x;
                     positions[count].y = y;
                     count++;

--- a/src/dungeon_8071B48.c
+++ b/src/dungeon_8071B48.c
@@ -69,7 +69,7 @@ void sub_8071B48(void)
         entity = dungeon->wildPokemon[index];
         if ((EntityIsValid(entity)) &&
            (tile = GetTile((entity->pos).x, (entity->pos).y),
-           (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE) == 0)) {
+           (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE) == 0)) {
           counter++;
         }
       }

--- a/src/dungeon_ai_attack.c
+++ b/src/dungeon_ai_attack.c
@@ -906,7 +906,7 @@ bool8 IsTargetInRange(Entity *pokemon, Entity *targetPokemon, s32 direction, s32
             }
             while (0); // Extra label needed to swap branch locations in ASM.
             mapTile = GetTile(currentPosX, currentPosY);
-            if (!(mapTile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+            if (!(mapTile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
             {
                 break;
             }

--- a/src/dungeon_ai_movement.c
+++ b/src/dungeon_ai_movement.c
@@ -124,7 +124,7 @@ bool8 CanTakeItem(Entity *pokemon)
         case ENTITY_ITEM:
             if (!pokemonInfo->isTeamLeader &&
                 !(pokemonInfo->heldItem.flags & ITEM_FLAG_EXISTS) &&
-                ((mapTile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) || !pokemonInfo->isNotTeamMember) &&
+                ((mapTile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) || !pokemonInfo->isNotTeamMember) &&
                 !(GetItemInfo(object)->flags & ITEM_FLAG_IN_SHOP))
             {
                 return TRUE;
@@ -551,7 +551,7 @@ bool8 AvoidEnemies(Entity *pokemon)
         if (room == closestTargetRoom && room != CORRIDOR_ROOM)
         {
             const Tile *tile = GetTile(pokemon->pos.x, pokemon->pos.y);
-            if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+            if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
             {
                 DungeonPos aiTargetPos;
                 s32 targetDir;
@@ -770,7 +770,7 @@ bool8 Wander(Entity *pokemon)
                 // it gives up and exits the way it came.
                 // This occurs normally for one-exit rooms, but can happen rarely for multi-exit rooms.
             }
-            if (GetTile(pokemon->pos.x, pokemon->pos.y)->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+            if (GetTile(pokemon->pos.x, pokemon->pos.y)->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
             {
                 s32 i;
                 targetFacingDir = DungeonRandInt(NUM_DIRECTIONS);

--- a/src/dungeon_cutscene_jirachi.c
+++ b/src/dungeon_cutscene_jirachi.c
@@ -258,7 +258,7 @@ static void JirachiWish(void)
         }
         pos.x = (jirachiEntity->pos.x + DungeonRandInt(3) - 1);
         pos.y = (jirachiEntity->pos.y + DungeonRandInt(3) + -1);
-        if ((GetTileMut(pos.x, pos.y)->terrainType & 3) != 0) {
+        if ((GetTileMut(pos.x, pos.y)->terrainFlags & 3) != 0) {
           PlaySoundEffect(0x14c);
           sub_808BB3C(&pos);
           sub_8046860(jirachiEntity,&pos,moneyItems,9);
@@ -284,7 +284,7 @@ static void JirachiWish(void)
         pos.x = (jirachiEntity->pos.x + DungeonRandInt(3) - 1);
         pos.y = (jirachiEntity->pos.y + DungeonRandInt(3) + -1);
 
-        if ((GetTileMut(pos.x, pos.y)->terrainType & 3) != 0) {
+        if ((GetTileMut(pos.x, pos.y)->terrainFlags & 3) != 0) {
           PlaySoundEffect(400);
           sub_808BB3C(&pos);
           sub_8046860(jirachiEntity,&pos,items,9);
@@ -341,7 +341,7 @@ static void JirachiWish(void)
           pos.x = (jirachiEntity->pos.x + DungeonRandInt(3) - 1);
           pos.y = (jirachiEntity->pos.y + DungeonRandInt(3) + -1);
 
-          if ((GetTileMut(pos.x, pos.y)->terrainType & 3) != 0) {
+          if ((GetTileMut(pos.x, pos.y)->terrainFlags & 3) != 0) {
             PlaySoundEffect(400);
             sub_808BB3C(&pos);
             sub_8046860(jirachiEntity,&pos,strengthItems,4);
@@ -504,9 +504,9 @@ static void CreateJirachiWishWarpTile(void)
   Tile *tile;
 
   tile = GetTileMut(gDungeon->unkE220[7].x, gDungeon->unkE220[7].y);
-  tile->terrainType &= ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-  tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
-  tile->terrainType &= ~TERRAIN_TYPE_STAIRS;
+  tile->terrainFlags &= ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+  tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
+  tile->terrainFlags &= ~TERRAIN_TYPE_STAIRS;
   sub_8049884();
   sub_8049B8C();
   UpdateTrapsVisibility();
@@ -518,10 +518,10 @@ static void EnableJirachiWishWarpTile(void)
   Tile *tile;
 
   tile = GetTileMut(gDungeon->unkE220[7].x, gDungeon->unkE220[7].y);
-  tile->terrainType &= ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-  tile->terrainType |= TERRAIN_TYPE_NORMAL;
-  tile->terrainType &= ~TERRAIN_TYPE_IMPASSABLE_WALL;
-  tile->terrainType |= TERRAIN_TYPE_STAIRS;
+  tile->terrainFlags &= ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+  tile->terrainFlags |= TERRAIN_TYPE_NORMAL;
+  tile->terrainFlags &= ~TERRAIN_TYPE_IMPASSABLE_WALL;
+  tile->terrainFlags |= TERRAIN_TYPE_STAIRS;
   tile->unk8 = 1;
   sub_8049884();
   sub_8049B8C();

--- a/src/dungeon_cutscene_regis.c
+++ b/src/dungeon_cutscene_regis.c
@@ -325,7 +325,7 @@ static void sub_808B1CC(u8 itemID)
     }
     sub_807FE04(&pos, 0);
     tile = GetTileMut(pos.x, pos.y);
-    tile->terrainType = tile->terrainType | TERRAIN_TYPE_STAIRS;
+    tile->terrainFlags = tile->terrainFlags | TERRAIN_TYPE_STAIRS;
     if (((itemID != ITEM_NOTHING) && (sub_80860A8(itemID) == 0)) &&
         (sub_80860A8(ITEM_MUSIC_BOX) == 0)) {
         ItemIdToItem(&item,itemID,0);

--- a/src/dungeon_damage.c
+++ b/src/dungeon_damage.c
@@ -367,7 +367,7 @@ static bool8 HandleDealingDamageInternal(Entity *attacker, Entity *target, struc
         if (arg8 != 0 && ShouldDisplayEntity(target)) {
             unkTile = GetTileAtEntitySafe(target);
             sub_803E708(0x14, 0x18);
-            unkTile->spawnOrVisibilityFlags |= 4;
+            unkTile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_TRAP;
             UpdateTrapsVisibility();
         }
         if (targetData->unk152 == 0) {
@@ -464,7 +464,7 @@ static bool8 HandleDealingDamageInternal(Entity *attacker, Entity *target, struc
 
         if (unkTile != NULL)
         {
-            unkTile->spawnOrVisibilityFlags &= ~(0x4);
+            unkTile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
             UpdateTrapsVisibility();
         }
         return FALSE;
@@ -479,7 +479,7 @@ static bool8 HandleDealingDamageInternal(Entity *attacker, Entity *target, struc
         sub_803E708(0x14, 0x18);
         target->unk22 = 2;
         sub_803E708(0xA, 0x18);
-        unkTile->spawnOrVisibilityFlags &= ~(0x4);
+        unkTile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
         UpdateTrapsVisibility();
     }
     else if (var_24) {

--- a/src/dungeon_generation.c
+++ b/src/dungeon_generation.c
@@ -333,7 +333,7 @@ void GenerateFloor(void)
                 for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
                     for (y = 0; y < DUNGEON_MAX_SIZE_Y; y++) {
                         const Tile *tile = GetTile(x, y);
-                        if ((tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_NORMAL && tile->room <= 240) {
+                        if ((tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_NORMAL && tile->room <= 240) {
                             roomTiles++;
                             if (tile->room < 64) {
                                 rooms[tile->room] = TRUE;
@@ -431,7 +431,7 @@ static void sub_804B534(s32 xStart, s32 yStart, s32 maxX, s32 maxY)
             s32 unkCount = 0;
             Tile *tile = GetTileMut(x, y);
 
-            tile->terrainType &= ~(TERRAIN_TYPE_CORNER_CUTTABLE);
+            tile->terrainFlags &= ~(TERRAIN_TYPE_CORNER_CUTTABLE);
             if (tile->room == CORRIDOR_ROOM && (GetTerrainType(tile) == TERRAIN_TYPE_NORMAL)) {
                 if (x > 0 && (GetTerrainType(GetTile(x - 1, y)) == TERRAIN_TYPE_NORMAL))
                     unkCount++;
@@ -444,7 +444,7 @@ static void sub_804B534(s32 xStart, s32 yStart, s32 maxX, s32 maxY)
                     unkCount++;
 
                 if (unkCount > 2) {
-                    tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                    tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
                 }
             }
         }
@@ -1317,7 +1317,7 @@ static void GenerateExtraHallways(struct GridCell grid[GRID_CELL_LEN][GRID_CELL_
                 break;
             if (GetTerrainType(GetTile(currX, currY)) == TERRAIN_TYPE_NORMAL)
                 break;
-            if (GetTile(currX, currY)->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)
+            if (GetTile(currX, currY)->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)
                 break;
 
             willNotMakeSquare = TRUE;
@@ -2911,9 +2911,9 @@ static void EnsureConnectedGrid(struct GridCell grid[GRID_CELL_LEN][GRID_CELL_LE
                 SetTerrainWall(tile);
 
             	// Also remove any spawn flags
-            	tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_STAIRS);
-            	tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_ITEM);
-            	tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_TRAP);
+            	tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_STAIRS);
+            	tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_ITEM);
+            	tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
             }
 		}
 	}
@@ -2933,9 +2933,9 @@ static void EnsureConnectedGrid(struct GridCell grid[GRID_CELL_LEN][GRID_CELL_LE
             		SetTerrainWall(tile);
 
             		// Remove any spawn flags
-            		tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_ITEM);
-                    tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_STAIRS);
-                    tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_TRAP);
+            		tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_ITEM);
+                    tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_STAIRS);
+                    tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
 
             		// Set room index to 0xFF (not a room)
             		tile->room = CORRIDOR_ROOM;
@@ -3002,7 +3002,7 @@ static void FinalizeJunctions(void)
                 if (x > 0) {
                     Tile *tile = GetTileMut(x - 1, y);
                     if (tile->room != CORRIDOR_ROOM) {
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
 
                         // If there's any water/lava on the junction tile, remove it
                         if (GetTerrainType(tile) == TERRAIN_TYPE_SECONDARY) {
@@ -3015,8 +3015,8 @@ static void FinalizeJunctions(void)
                     Tile *tile = GetTileMut(x, y - 1);
                     if (tile->room != CORRIDOR_ROOM) {
                         // Yes, these |= have to be duplicated in order to match. Either it's an error and they wanted to use a different flag, or just copy-pasted it twice.
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
                         if (GetTerrainType(tile) == TERRAIN_TYPE_SECONDARY) {
                             SetTerrainType(tile, TERRAIN_TYPE_NORMAL);
                         }
@@ -3026,8 +3026,8 @@ static void FinalizeJunctions(void)
                 if (y < DUNGEON_MAX_SIZE_Y - 1) {
                     Tile *tile = GetTileMut(x, y + 1);
                     if (tile->room != CORRIDOR_ROOM) {
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
                         if (GetTerrainType(tile) == TERRAIN_TYPE_SECONDARY) {
                             SetTerrainType(tile, TERRAIN_TYPE_NORMAL);
                         }
@@ -3037,8 +3037,8 @@ static void FinalizeJunctions(void)
                 if (x < DUNGEON_MAX_SIZE_X - 1) {
                     Tile *tile = GetTileMut(x + 1, y);
                     if (tile->room != CORRIDOR_ROOM) {
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
-                        tile->terrainType |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
+                        tile->terrainFlags |= TERRAIN_TYPE_NATURAL_JUNCTION;
                         if (GetTerrainType(tile) == TERRAIN_TYPE_SECONDARY) {
                             SetTerrainType(tile, TERRAIN_TYPE_NORMAL);
                         }
@@ -3066,7 +3066,7 @@ void sub_804EB30(void)
 
     for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
         for (y = 0; y < DUNGEON_MAX_SIZE_Y; y++) {
-            if (GetTile(x, y)->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION) {
+            if (GetTile(x, y)->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION) {
                 u32 roomIndex = GetTile(x, y)->room;
                 if (roomIndex < MAX_ROOM_COUNT && dungeon->naturalJunctionListCounts[roomIndex] < MAX_ROOM_COUNT) {
                     dungeon->naturalJunctionList[roomIndex][dungeon->naturalJunctionListCounts[roomIndex]].x = x;
@@ -3198,11 +3198,11 @@ static void GenerateKecleonShop(struct GridCell grid[GRID_CELL_LEN][GRID_CELL_LE
             	for (curY = sKecleonShopPosition.minY; curY < sKecleonShopPosition.maxY; curY++) {
                     Tile *tile = GetTileMut(curX, curY);
 
-                    tile->terrainType |= TERRAIN_TYPE_SHOP;
+                    tile->terrainFlags |= TERRAIN_TYPE_SHOP;
 
             		// Restrict monsters and stairs from spawning here
-            		tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_MONSTER);
-            		tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_STAIRS);
+            		tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_MONSTER);
+            		tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_STAIRS);
 
             		// Ensure the borders are assigned properly
             		if (dungeon->kecleonShopPos.minX > curX) {
@@ -3226,7 +3226,7 @@ static void GenerateKecleonShop(struct GridCell grid[GRID_CELL_LEN][GRID_CELL_LE
             // Sets an unknown spawn flag for all tiles in the room
             for (curX = grid[x][y].start.x; curX < grid[x][y].end.x; curX++) {
             	for (curY = grid[x][y].start.y; curY < grid[x][y].end.y; curY++) {
-                    GetTileMut(curX, curY)->spawnOrVisibilityFlags |= SPAWN_FLAG_SPECIAL_TILE;
+                    GetTileMut(curX, curY)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_SPECIAL_TILE;
             	}
             }
 
@@ -3352,7 +3352,7 @@ static void GenerateMonsterHouse(struct GridCell grid[GRID_CELL_LEN][GRID_CELL_L
 
                 for (curX = grid[x][y].start.x; curX < grid[x][y].end.x; curX++) {
                     for (curY = grid[x][y].start.y; curY < grid[x][y].end.y; curY++) {
-                        GetTileMut(curX, curY)->terrainType |= TERRAIN_TYPE_IN_MONSTER_HOUSE;
+                        GetTileMut(curX, curY)->terrainFlags |= TERRAIN_TYPE_IN_MONSTER_HOUSE;
                         dungeon->monsterHouseRoom = GetTile(curX, curY)->room;
                     }
                 }
@@ -3658,7 +3658,7 @@ static void GenerateMazeLine(s32 x0, s32 y0, s32 xMin, s32 yMin, s32 xMax, s32 y
 static void SetTerrainSecondaryWithFlag(Tile *tile, u32 additionalFlag)
 {
     SetTerrainSecondary(tile);
-    tile->terrainType |= additionalFlag;
+    tile->terrainFlags |= additionalFlag;
 }
 
 /*
@@ -3670,7 +3670,7 @@ static void SetSpawnFlag5(struct GridCell *gridCell)
 
 	for (x = gridCell->start.x; x < gridCell->end.x; x++) {
 		for (y = gridCell->start.y; y < gridCell->end.y; y++) {
-            GetTileMut(x, y)->spawnOrVisibilityFlags |= SPAWN_FLAG_UNK5;
+            GetTileMut(x, y)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_UNK5;
 		}
 	}
 }
@@ -3739,7 +3739,7 @@ static void GenerateSecondaryStructure(struct GridCell *gridCell)
 
                         for (curX = gridCell->start.x; curX < middleX; curX++) {
                         	for (curY = gridCell->start.y; curY < gridCell->end.y; curY++) {
-                                GetTileMut(curX, curY)->terrainType |= TERRAIN_TYPE_UNK_7;
+                                GetTileMut(curX, curY)->terrainFlags |= TERRAIN_TYPE_UNK_7;
                         	}
                         }
 
@@ -3766,7 +3766,7 @@ static void GenerateSecondaryStructure(struct GridCell *gridCell)
 
                         for (curY = gridCell->start.y; curY < middleY; curY++) {
                             for (curX = gridCell->start.x; curX < gridCell->end.x; curX++) {
-                        		GetTileMut(curX, curY)->terrainType |= TERRAIN_TYPE_UNK_7;
+                        		GetTileMut(curX, curY)->terrainFlags |= TERRAIN_TYPE_UNK_7;
                         	}
                         }
 
@@ -3802,18 +3802,18 @@ static void GenerateSecondaryStructure(struct GridCell *gridCell)
                     SetTerrainSecondaryWithFlag(GetTileMut(middleX + 1, middleY + 1), TERRAIN_TYPE_CORNER_CUTTABLE);
 
                     // Trap
-                    GetTileMut(middleX - 1, middleY - 1)->spawnOrVisibilityFlags |= SPAWN_FLAG_TRAP;
+                    GetTileMut(middleX - 1, middleY - 1)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_TRAP;
                     // Warp Tile ?
-                    GetTileMut(middleX - 1, middleY - 1)->spawnOrVisibilityFlags |= SPAWN_FLAG_UNK6;
+                    GetTileMut(middleX - 1, middleY - 1)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_UNK6;
 
                     // Items
-                    GetTileMut(middleX, middleY - 1)->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
-                    GetTileMut(middleX - 1, middleY)->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
-                    GetTileMut(middleX, middleY)->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
-                    GetTileMut(middleX - 1, middleY - 1)->spawnOrVisibilityFlags |= SPAWN_FLAG_SPECIAL_TILE;
-                    GetTileMut(middleX, middleY - 1)->spawnOrVisibilityFlags |= SPAWN_FLAG_SPECIAL_TILE;
-                    GetTileMut(middleX - 1, middleY)->spawnOrVisibilityFlags |= SPAWN_FLAG_SPECIAL_TILE;
-                    GetTileMut(middleX, middleY)->spawnOrVisibilityFlags |= SPAWN_FLAG_SPECIAL_TILE;
+                    GetTileMut(middleX, middleY - 1)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
+                    GetTileMut(middleX - 1, middleY)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
+                    GetTileMut(middleX, middleY)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
+                    GetTileMut(middleX - 1, middleY - 1)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_SPECIAL_TILE;
+                    GetTileMut(middleX, middleY - 1)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_SPECIAL_TILE;
+                    GetTileMut(middleX - 1, middleY)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_SPECIAL_TILE;
+                    GetTileMut(middleX, middleY)->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_SPECIAL_TILE;
 
                     gridCell->hasSecondaryStructure = TRUE;
                 }
@@ -3921,23 +3921,23 @@ static void ResolveInvalidSpawns(void)
         for (y = 0; y < DUNGEON_MAX_SIZE_Y; y++) {
             Tile *tile = GetTileMut(x, y);
             if (GetTerrainType(tile) != TERRAIN_TYPE_NORMAL) {
-                if (tile->terrainType & (TERRAIN_TYPE_UNBREAKABLE | TERRAIN_TYPE_IMPASSABLE_WALL)) {
+                if (tile->terrainFlags & (TERRAIN_TYPE_UNBREAKABLE | TERRAIN_TYPE_IMPASSABLE_WALL)) {
                     // This tile is an impassable obstacle, make sure no items spawn here
-                    tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_ITEM);
+                    tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_ITEM);
                 }
                 // This tile is an obstacle, make sure no traps spawn here
-                tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_TRAP);
+                tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
             }
 
-            if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_STAIRS) {
+            if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_STAIRS) {
                 // This tile has the stairs, make sure the stairs bit is set and
             	// make sure no traps spawn here
-                tile->terrainType |= TERRAIN_TYPE_STAIRS;
-                tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_TRAP);
+                tile->terrainFlags |= TERRAIN_TYPE_STAIRS;
+                tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
             }
-            if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_ITEM) {
+            if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM) {
                 //This tile is an item spawn, make sure no traps spawn here
-                tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_TRAP);
+                tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_TRAP);
             }
         }
     }
@@ -3966,7 +3966,7 @@ static void EnsureImpassableTilesAreWalls(void)
 
     for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
         for (y = 0; y < DUNGEON_MAX_SIZE_Y; y++) {
-            if (GetTile(x, y)->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) {
+            if (GetTile(x, y)->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) {
                 SetTerrainWall(GetTileMut(x,y));
             }
         }
@@ -3975,8 +3975,8 @@ static void EnsureImpassableTilesAreWalls(void)
 
 static void ResetTile(Tile *tile)
 {
-    tile->terrainType = 0;
-    tile->spawnOrVisibilityFlags = 0;
+    tile->terrainFlags = 0;
+    tile->spawnOrVisibilityFlags.spawn = 0;
     tile->room = -1;
     tile->unk8 = 0;
     tile->walkableNeighborFlags[CROSSABLE_TERRAIN_REGULAR] = 0;
@@ -4020,7 +4020,7 @@ static void ResetFloor(void)
                 (PosIsOutOfBounds(x - 1, y))     ||
                 (PosIsOutOfBounds(x - 1, y - 1)))
             {
-                GetTileMut(x,y)->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+                GetTileMut(x,y)->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
             }
         }
     }
@@ -4102,15 +4102,15 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
                     continue;
                 if (tile->room == CORRIDOR_ROOM)
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_SHOP)
+                if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                     continue;
-                if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_MONSTER)
+                if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_MONSTER)
                     continue;
-                if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_SPECIAL_TILE)
+                if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_SPECIAL_TILE)
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+                if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)
+                if (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)
                     continue;
 
                 validSpawns[count].x = x;
@@ -4124,8 +4124,8 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
             s32 stairsIndex = DungeonRandInt(count);
             Tile *stairsTile = GetTileMut(validSpawns[stairsIndex].x, validSpawns[stairsIndex].y);
 
-            stairsTile->spawnOrVisibilityFlags |= SPAWN_FLAG_STAIRS;
-            stairsTile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_ITEM);
+            stairsTile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_STAIRS;
+            stairsTile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_ITEM);
             sStairsRoomIndex = stairsTile->room;
             dungeon->stairsSpawn.x = validSpawns[stairsIndex].x;
             dungeon->stairsSpawn.y = validSpawns[stairsIndex].y;
@@ -4137,7 +4137,7 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
                     for (y = 0; y < DUNGEON_MAX_SIZE_Y; y++) {
                         Tile *tile = GetTileMut(x, y);
                         if (GetTerrainType(tile) == TERRAIN_TYPE_NORMAL && tile->room == stairsRoomIndex) {
-                            tile->terrainType |= TERRAIN_TYPE_IN_MONSTER_HOUSE;
+                            tile->terrainFlags |= TERRAIN_TYPE_IN_MONSTER_HOUSE;
                             dungeon->monsterHouseRoom = tile->room;
                         }
                     }
@@ -4164,13 +4164,13 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
                 continue;
             if (tile->room == CORRIDOR_ROOM)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_SHOP)
+            if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE)
+            if (tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+            if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)
+            if (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)
                 continue;
 
             validSpawns[count].x = x;
@@ -4195,7 +4195,7 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
             randIndex = DungeonRandInt(count);
             for (i = 0; i < numItems; i++) {
             	Tile *tile = GetTileMut(validSpawns[randIndex].x, validSpawns[randIndex].y);
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
 
                 randIndex++;
                 if (randIndex == count) {
@@ -4234,7 +4234,7 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
             randIndex = DungeonRandInt(count);
             for (i = 0; i < numItems; i++) {
             	Tile *tile = GetTileMut(validSpawns[randIndex].x, validSpawns[randIndex].y);
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
 
                 randIndex++;
                 if (randIndex == count) {
@@ -4255,11 +4255,11 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
             	// - in a Monster House
             	// - not a junction (near a hallway)
             	const Tile *tile = GetTile(x, y);
-                if (tile->terrainType & TERRAIN_TYPE_SHOP)
+                if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                     continue;
-                if (!(tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE))
+                if (!(tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE))
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+                if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
                     continue;
 
                 validSpawns[count].x = x;
@@ -4290,10 +4290,10 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
             // 50/50 chance of spawning an item or a trap
             if (DungeonRandInt(2) != 0) {
                 // Spawn an item
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
             }
             else if (gDungeon->unk644.unk18) {
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_TRAP;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_TRAP;
             }
 
             randIndex++;
@@ -4321,13 +4321,13 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
                 continue;
             if (tile->room == CORRIDOR_ROOM)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_SHOP)
+            if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                 continue;
-            if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_ITEM)
+            if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+            if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)
+            if (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)
                 continue;
 
             validSpawns[count].x = x;
@@ -4351,7 +4351,7 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
             trapIndex = DungeonRandInt(count);
             for (i = 0; i < numTraps; i++) {
             	Tile *tile = GetTileMut(validSpawns[trapIndex].x, validSpawns[trapIndex].y);
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_TRAP;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_TRAP;
 
                 trapIndex++;
                 if (trapIndex == count) {
@@ -4380,17 +4380,17 @@ static void SpawnNonEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHou
                     continue;
                 if (tile->room == CORRIDOR_ROOM)
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_SHOP)
+                if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+                if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
                     continue;
-                if (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)
+                if (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)
                     continue;
-                if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_ITEM)
+                if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)
                     continue;
-                if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_MONSTER)
+                if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_MONSTER)
                     continue;
-                if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_TRAP)
+                if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_TRAP)
                     continue;
 
                 validSpawns[count].x = x;
@@ -4450,15 +4450,15 @@ static void SpawnEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHouse)
                 continue;
             if (tile->room == CORRIDOR_ROOM)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_SHOP)
+            if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                 continue;
-            if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_ITEM)
+            if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)
                 continue;
-            if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_STAIRS)
+            if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_STAIRS)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+            if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)
+            if (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)
                 continue;
             if (x == dungeon->playerSpawn.x && y == dungeon->playerSpawn.y)
                 continue;
@@ -4482,7 +4482,7 @@ static void SpawnEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHouse)
             for (i = 0; i < numEnemies; i++) {
                 Tile *tile = GetTileMut(validSpawns[randIndex].x, validSpawns[randIndex].y);
                  // Spawn an enemy here
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_MONSTER;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_MONSTER;
 
                 randIndex++;
                 if (randIndex == count) {
@@ -4525,11 +4525,11 @@ static void SpawnEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHouse)
                 continue;
             if (tile->room == CORRIDOR_ROOM)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_SHOP)
+            if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
                 continue;
-            if (tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)
+            if (tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)
                 continue;
-            if (!(tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE))
+            if (!(tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE))
                 continue;
             if (x == dungeon->playerSpawn.x && y == dungeon->playerSpawn.y)
                 continue;
@@ -4559,7 +4559,7 @@ static void SpawnEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHouse)
         for (i = 0; i < numEnemies; i++) {
             Tile *tile = GetTileMut(validSpawns[randIndex].x, validSpawns[randIndex].y);
              // Spawn an enemy here
-            tile->spawnOrVisibilityFlags |= SPAWN_FLAG_MONSTER;
+            tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_MONSTER;
 
             randIndex++;
             if (randIndex == count) {
@@ -4579,7 +4579,7 @@ void SetSecondaryTerrainOnWall(Tile *tile)
     bool8 isWall = TRUE;
     if (GetTerrainType(tile) != TERRAIN_TYPE_WALL)
         isWall = FALSE;
-    if (tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)
+    if (tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)
         isWall = FALSE;
 
     if (isWall) {
@@ -4852,7 +4852,7 @@ static void GenerateSecondaryTerrainFormations(u32 flag, FloorProperties *floorP
             // This really shouldn't happen since we only place terrain on wall tiles to begin with,
             // but it provides additional safety
 
-            if (tile->terrainType & (TERRAIN_TYPE_SHOP | TERRAIN_TYPE_IN_MONSTER_HOUSE | TERRAIN_TYPE_UNBREAKABLE) || (tile->spawnOrVisibilityFlags & SPAWN_FLAG_STAIRS)) {
+            if (tile->terrainFlags & (TERRAIN_TYPE_SHOP | TERRAIN_TYPE_IN_MONSTER_HOUSE | TERRAIN_TYPE_UNBREAKABLE) || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_STAIRS)) {
                 SetTerrainNormal(tile);
             }
             else {
@@ -5605,17 +5605,17 @@ bool8 StairsAlwaysReachable(s32 stairsX, s32 stairsY, bool8 markUnreachable)
             test[x][y] = 0;
             if (markUnreachable) {
             	// Reset all unreachable flags on tiles, they'll be recomputed from scratch
-            	tile->terrainType &= ~(TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS);
+            	tile->terrainFlags &= ~(TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS);
             }
 
             if (terrain != TERRAIN_TYPE_NORMAL) {
-            	if (!(tile->terrainType & TERRAIN_TYPE_CORNER_CUTTABLE)) {
+            	if (!(tile->terrainFlags & TERRAIN_TYPE_CORNER_CUTTABLE)) {
             		test[x][y] |= STAIRS_FLAG_CANNOT_CORNER_CUT;
             	}
             }
 
             if (terrain == TERRAIN_TYPE_SECONDARY) {
-            	if (!(tile->terrainType & TERRAIN_TYPE_CORNER_CUTTABLE)) {
+            	if (!(tile->terrainFlags & TERRAIN_TYPE_CORNER_CUTTABLE)) {
             		test[x][y] |= STAIRS_FLAG_SECONDARY_TERRAIN_CANNOT_CORNER_CUT;
             	}
             }
@@ -5715,12 +5715,12 @@ bool8 StairsAlwaysReachable(s32 stairsX, s32 stairsY, bool8 markUnreachable)
             if (!(test[x][y] & (STAIRS_FLAG_CANNOT_CORNER_CUT | STAIRS_FLAG_SECONDARY_TERRAIN_CANNOT_CORNER_CUT | STAIRS_FLAG_UNKNOWN | STAIRS_FLAG_VISITED))) {
                 // This is an open tile that wasn't visited by BFS, which means it's unreachable from the starting stairs
                 if (markUnreachable) {
-                    tile->terrainType |= TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS;
+                    tile->terrainFlags |= TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS;
                 }
                 else {
                     // unbreakable tiles can't really be navigated onto anyways, so if
             		// we can ignore the tile (otherwise it's a problem!)
-            		if (!(tile->terrainType & TERRAIN_TYPE_UNBREAKABLE)) {
+            		if (!(tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE)) {
                         return FALSE;
             		}
                 }
@@ -5882,7 +5882,7 @@ static u8 sub_80511F0(void)
 
 static bool8 sub_805124C(Tile *tile, u8 a1, s32 x, s32 y, bool8 spawnTrapOrItem)
 {
-    tile->terrainType |= TERRAIN_TYPE_UNBREAKABLE;
+    tile->terrainFlags |= TERRAIN_TYPE_UNBREAKABLE;
     tile->unkE = 0;
     return PlaceFixedRoomTile(tile, a1, x, y, spawnTrapOrItem);
 }
@@ -5913,7 +5913,7 @@ static void sub_8051288(s32 fixedRoomNumber)
         for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
             if (x <= 4 || x >= fixedRoomSizeX + 5 || y <= 4 || y >= fixedRoomSizeY + 5) {
                 Tile *tile = GetTileMut(x, y);
-                tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+                tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
                 if (gUnknown_202F1A8) {
                     SetTerrainType(tile, TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
                 }
@@ -5928,7 +5928,7 @@ static void sub_8051288(s32 fixedRoomNumber)
         for (y = 5; y < 17; y++) {
             for (x = 2; x < 5; x++) {
                 Tile *tile = GetTileMut(x, y);
-                tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+                tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
                 SetTerrainWall(tile);
             }
         }
@@ -5939,7 +5939,7 @@ static void sub_8051288(s32 fixedRoomNumber)
             for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
                 Tile *tile = GetTileMut(x, y);
                 if (GetTerrainType(tile) == TERRAIN_TYPE_WALL) {
-                    tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+                    tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
                 }
             }
         }
@@ -5977,7 +5977,7 @@ static void sub_8051438(struct GridCell *gridCell, s32 fixedRoomNumber)
                 roomId = tile->room;
                 *tile = dungeon->unkE27C[xIndex][yIndex];
                 if (x >= gridCell->start.x + 2 && x < gridCell->end.x - 2 && y >= gridCell->start.y + 2 && y < gridCell->end.y - 2) {
-                    tile->terrainType = TERRAIN_TYPE_IMPASSABLE_WALL | TERRAIN_TYPE_UNBREAKABLE;
+                    tile->terrainFlags = TERRAIN_TYPE_IMPASSABLE_WALL | TERRAIN_TYPE_UNBREAKABLE;
                     tile->unkE = 0xE;
                 }
                 tile->room = roomId;
@@ -6037,7 +6037,7 @@ static void sub_8051654(FloorProperties *floorProps)
         if (DungeonRandInt(100) < 50) {
             s32 y;
             for (y = sKecleonShopPosition.minY; y < sKecleonShopPosition.maxY; y++) {
-                GetTileMut(sKecleonShopPosition.minX, y)->terrainType &= ~(TERRAIN_TYPE_SHOP);
+                GetTileMut(sKecleonShopPosition.minX, y)->terrainFlags &= ~(TERRAIN_TYPE_SHOP);
             }
             sKecleonShopPosition.minX++;
         }
@@ -6045,7 +6045,7 @@ static void sub_8051654(FloorProperties *floorProps)
             s32 y;
             sKecleonShopPosition.maxX--;
             for (y = sKecleonShopPosition.minY; y < sKecleonShopPosition.maxY; y++) {
-                GetTileMut(sKecleonShopPosition.maxX, y)->terrainType &= ~(TERRAIN_TYPE_SHOP);
+                GetTileMut(sKecleonShopPosition.maxX, y)->terrainFlags &= ~(TERRAIN_TYPE_SHOP);
             }
         }
     }
@@ -6057,7 +6057,7 @@ static void sub_8051654(FloorProperties *floorProps)
         if (DungeonRandInt(100) < 50) {
             s32 x;
             for (x = sKecleonShopPosition.minX; x < sKecleonShopPosition.maxX; x++) {
-                GetTileMut(x, sKecleonShopPosition.minY)->terrainType &= ~(TERRAIN_TYPE_SHOP);
+                GetTileMut(x, sKecleonShopPosition.minY)->terrainFlags &= ~(TERRAIN_TYPE_SHOP);
             }
             sKecleonShopPosition.minY++;
         }
@@ -6065,7 +6065,7 @@ static void sub_8051654(FloorProperties *floorProps)
             s32 x;
             sKecleonShopPosition.maxY--;
             for (x = sKecleonShopPosition.minX; x < sKecleonShopPosition.maxX; x++) {
-                GetTileMut(x, sKecleonShopPosition.maxY)->terrainType &= ~(TERRAIN_TYPE_SHOP);
+                GetTileMut(x, sKecleonShopPosition.maxY)->terrainFlags &= ~(TERRAIN_TYPE_SHOP);
             }
         }
     }
@@ -6073,12 +6073,12 @@ static void sub_8051654(FloorProperties *floorProps)
     for (x = sKecleonShopPosition.minX; x < sKecleonShopPosition.maxX; x++) {
         for (y = sKecleonShopPosition.minY; y < sKecleonShopPosition.maxY; y++) {
             Tile *tile = GetTileMut(x, y);
-            if (!(tile->terrainType & TERRAIN_TYPE_SHOP))
+            if (!(tile->terrainFlags & TERRAIN_TYPE_SHOP))
                 continue;
-            if (!(tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION))
+            if (!(tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION))
                 continue;
 
-            tile->terrainType &= ~(TERRAIN_TYPE_SHOP);
+            tile->terrainFlags &= ~(TERRAIN_TYPE_SHOP);
         }
     }
 
@@ -6089,15 +6089,15 @@ static void sub_8051654(FloorProperties *floorProps)
         yIndex = 0;
         for (y = middleY; y < middleY + 3; y++, yIndex++) {
             Tile *tile = GetTileMut(x, y);
-            if (!(tile->terrainType & TERRAIN_TYPE_SHOP))
+            if (!(tile->terrainFlags & TERRAIN_TYPE_SHOP))
                 continue;
-            if ((tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE))
+            if ((tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE))
                 continue;
-            if ((tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION))
+            if ((tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION))
                 continue;
 
             if (sKecleonShopItemSpawnChances[floorProps->unk18][yIndex][xIndex] > DungeonRandInt(100)) {
-                tile->spawnOrVisibilityFlags |= SPAWN_FLAG_ITEM;
+                tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
             }
         }
     }
@@ -6117,13 +6117,13 @@ static void ResetInnerBoundaryTileRows(void)
         Tile *tile = GetTileMut(x, 1);
         ResetTile(tile);
         if (x == 0 || x == DUNGEON_MAX_SIZE_X - 1) {
-            tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+            tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
         }
 
         tile = GetTileMut(x, 30);
         ResetTile(tile);
         if (x == 0 || x == DUNGEON_MAX_SIZE_X - 1) {
-            tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+            tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
         }
     }
 }

--- a/src/dungeon_generation_fixed.c
+++ b/src/dungeon_generation_fixed.c
@@ -865,7 +865,7 @@ bool8 PlaceFixedRoomTile(Tile *tile, u8 fixedRoomActionId, s32 x, s32 y, bool8 s
             break;
         case 1:
             SetTerrainWall(tile);
-            tile->terrainType &= ~(TERRAIN_TYPE_UNBREAKABLE);
+            tile->terrainFlags &= ~(TERRAIN_TYPE_UNBREAKABLE);
             tile->room = CORRIDOR_ROOM;
             break;
         case 4:
@@ -888,22 +888,22 @@ bool8 PlaceFixedRoomTile(Tile *tile, u8 fixedRoomActionId, s32 x, s32 y, bool8 s
             // fall through
         case 10:
             SetTerrainType(tile, TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL);
-            tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+            tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
             tile->room = CORRIDOR_ROOM;
             break;
         case 8:
         case 67:
             SetTerrainNormal(tile);
-            tile->spawnOrVisibilityFlags |= SPAWN_FLAG_STAIRS;
-            tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_ITEM);
+            tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_STAIRS;
+            tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_ITEM);
             tile->room = 0;
             gDungeon->stairsSpawn.x = x;
             gDungeon->stairsSpawn.y = y;
             break;
         case 68:
-            tile->terrainType |= TERRAIN_TYPE_UNK_x800;
+            tile->terrainFlags |= TERRAIN_TYPE_UNK_x800;
             SetTerrainNormal(tile);
-            tile->spawnOrVisibilityFlags &= ~(SPAWN_FLAG_ITEM);
+            tile->spawnOrVisibilityFlags.spawn &= ~(SPAWN_FLAG_ITEM);
             tile->room = 0;
             break;
         case 9:
@@ -912,21 +912,21 @@ bool8 PlaceFixedRoomTile(Tile *tile, u8 fixedRoomActionId, s32 x, s32 y, bool8 s
             break;
         case 11:
             SetTerrainNormal(tile);
-            tile->terrainType |= TERRAIN_TYPE_UNK_x800;
+            tile->terrainFlags |= TERRAIN_TYPE_UNK_x800;
             tile->room = 0;
             break;
         case 12:
             SetTerrainNormal(tile);
-            tile->terrainType |= TERRAIN_TYPE_UNK_x1000;
-            tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
-            tile->terrainType |= TERRAIN_TYPE_UNK_x800;
+            tile->terrainFlags |= TERRAIN_TYPE_UNK_x1000;
+            tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
+            tile->terrainFlags |= TERRAIN_TYPE_UNK_x800;
             tile->room = 0;
             break;
         case 2:
         case 13:
         case 14:
             SetTerrainWall(tile);
-            tile->terrainType |= TERRAIN_TYPE_IMPASSABLE_WALL;
+            tile->terrainFlags |= TERRAIN_TYPE_IMPASSABLE_WALL;
             tile->room = CORRIDOR_ROOM;
             break;
         default:
@@ -990,7 +990,7 @@ void sub_8051E7C(Entity *pokemon)
 {
     Tile *tile = GetTileMut(pokemon->pos.x, pokemon->pos.y - 1);
 
-    if (!(tile->terrainType & TERRAIN_TYPE_UNK_x1000)) {
+    if (!(tile->terrainFlags & TERRAIN_TYPE_UNK_x1000)) {
         LogMessageByIdWithPopupCheckUser(pokemon, gUnknown_80FDDF0); // It can't be used here!
     }
     else if (!gDungeon->unk3A09) {
@@ -1014,13 +1014,13 @@ void sub_8051E7C(Entity *pokemon)
                     continue;
 
                 loopTile = GetTileMut(x, y);
-                if (loopTile->terrainType & TERRAIN_TYPE_UNBREAKABLE) {
-                    loopTile->terrainType = gDungeon->unkE27C[xDiff][yDiff].terrainType;
-                    loopTile->spawnOrVisibilityFlags = gDungeon->unkE27C[xDiff][yDiff].spawnOrVisibilityFlags;
+                if (loopTile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE) {
+                    loopTile->terrainFlags = gDungeon->unkE27C[xDiff][yDiff].terrainFlags;
+                    loopTile->spawnOrVisibilityFlags.visibility = gDungeon->unkE27C[xDiff][yDiff].spawnOrVisibilityFlags.visibility;
                 }
 
                 PlaceFixedRoomTile(loopTile, gDungeon->unkE87C[xDiff][yDiff], x, y, TRUE);
-                loopTile->spawnOrVisibilityFlags |= 3;
+                loopTile->spawnOrVisibilityFlags.visibility |= (VISIBILITY_FLAG_REVEALED | VISIBILITY_FLAG_VISITED);
                 if (roomId != CORRIDOR_ROOM) {
                     loopTile->room = roomId;
                 }
@@ -1046,7 +1046,7 @@ void sub_8051E7C(Entity *pokemon)
         }
 
         gDungeon->unk3A09 = TRUE;
-        tile->terrainType &= ~(TERRAIN_TYPE_IMPASSABLE_WALL | TERRAIN_TYPE_UNK_x1000);
+        tile->terrainFlags &= ~(TERRAIN_TYPE_IMPASSABLE_WALL | TERRAIN_TYPE_UNK_x1000);
         sub_80498A8(pokemon->pos.x, pokemon->pos.y - 1);
         sub_8049B8C();
         UpdateTrapsVisibility();

--- a/src/dungeon_items.c
+++ b/src/dungeon_items.c
@@ -122,13 +122,13 @@ void CreateFloorItems(void)
             }
             tile = GetTile(x,y);
 
-            if (!(tile->terrainType & TERRAIN_TYPE_STAIRS) && (tile->spawnOrVisibilityFlags & SPAWN_FLAG_ITEM)) {
+            if (!(tile->terrainFlags & TERRAIN_TYPE_STAIRS) && (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) {
                 DungeonPos pos;
                 bool8 shopFlag = FALSE;
                 pos.x = x;
                 pos.y = y;
 
-                if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+                if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
                     shopFlag = TRUE;
                     spawnType = ITEM_SPAWN_IN_SHOP;
                 }
@@ -138,7 +138,7 @@ void CreateFloorItems(void)
                         spawnType = ITEM_SPAWN_WALL;
                     }
                     else {
-                        spawnType = (tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE) ? ITEM_SPAWN_IN_MONSTER_HOUSE : ITEM_SPAWN_NORMAL;
+                        spawnType = (tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE) ? ITEM_SPAWN_IN_MONSTER_HOUSE : ITEM_SPAWN_NORMAL;
                     }
                 }
                 itemID = GetRandomFloorItem(spawnType);
@@ -319,7 +319,7 @@ bool8 SpawnItem(DungeonPos *pos, Item *item, bool8 a2)
     itemEntity->isVisible = TRUE;
     tile = GetTileMut(pos->x, pos->y);
     tile->object = itemEntity;
-    if ((tile->terrainType & TERRAIN_TYPE_SHOP) && IsShoppableItem(item->id)) {
+    if ((tile->terrainFlags & TERRAIN_TYPE_SHOP) && IsShoppableItem(item->id)) {
         if (item->flags & ITEM_FLAG_IN_SHOP) {
             if (a2) {
                 gDungeon->unk644.unk48 += GetActualBuyPrice(item);
@@ -350,7 +350,7 @@ bool8 RemoveGroundItem(DungeonPos *pos, bool8 a2)
         return FALSE;
 
     item = GetItemInfo(tileObject);
-    if ((tile->terrainType & TERRAIN_TYPE_SHOP) && IsShoppableItem(item->id)) {
+    if ((tile->terrainFlags & TERRAIN_TYPE_SHOP) && IsShoppableItem(item->id)) {
         if (item->flags & ITEM_FLAG_IN_SHOP) {
             if (a2) {
                 gDungeon->unk644.unk48 -= GetActualBuyPrice(item);
@@ -388,11 +388,11 @@ bool8 sub_80462AC(Entity * entity, u8 hallucinating, u8 a2, u8 a3, u8 a4)
         return FALSE;
 
     if (a2) {
-        s32 terrainType = GetTerrainType(GetTile(entity->pos.x, entity->pos.y));
+        s32 terrainFlags = GetTerrainType(GetTile(entity->pos.x, entity->pos.y));
 
-        if (terrainType == TERRAIN_TYPE_WALL)
+        if (terrainFlags == TERRAIN_TYPE_WALL)
             return FALSE;
-        if (terrainType == TERRAIN_TYPE_SECONDARY) {
+        if (terrainFlags == TERRAIN_TYPE_SECONDARY) {
             objMode = 1;
         }
 
@@ -496,7 +496,7 @@ void SpawnDroppedItem(Entity *entity1, Entity *entity2, Item *item, bool8 a3, Du
         localPos.x = entity2->pos.x + gUnknown_80F4468[i].x;
         localPos.y = entity2->pos.y + gUnknown_80F4468[i].y;
         tile = GetTile(localPos.x, localPos.y);
-        if (GetTerrainType(tile) != TERRAIN_TYPE_WALL && !(tile->terrainType & TERRAIN_TYPE_STAIRS) && tile->object == NULL) {
+        if (GetTerrainType(tile) != TERRAIN_TYPE_WALL && !(tile->terrainFlags & TERRAIN_TYPE_STAIRS) && tile->object == NULL) {
             sub_8046734(entity2, &localPos);
             localPos2 = localPos;
             if (GetTerrainType(tile) == (TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL) || (SpawnItem(&localPos, item, TRUE))) {
@@ -617,7 +617,7 @@ void sub_804687C(Entity *entity, DungeonPos *pos1, DungeonPos *pos2, Item *item,
                 pos.y = pos2->y + gUnknown_80F4468[j].y;
 
                 tile = GetTile(pos.x, pos.y);
-                if (GetTerrainType(tile) != TERRAIN_TYPE_WALL && !(tile->terrainType & TERRAIN_TYPE_STAIRS) && tile->object == NULL) {
+                if (GetTerrainType(tile) != TERRAIN_TYPE_WALL && !(tile->terrainFlags & TERRAIN_TYPE_STAIRS) && tile->object == NULL) {
                     targetTilePos[i] = pos;
                     targetTileUsed[j] = TRUE;
                     foundTile = TRUE;

--- a/src/dungeon_kecleon_shop.c
+++ b/src/dungeon_kecleon_shop.c
@@ -50,7 +50,7 @@ void sub_807EC28(bool8 arg0)
     leader = GetLeader();
     leaderInfo = GetEntInfo(leader);
     prevTileWasShop = gDungeon->unk644.unk54;
-    isShopTile = (GetTileAtEntitySafe(leader)->terrainType & TERRAIN_TYPE_SHOP) != 0;
+    isShopTile = (GetTileAtEntitySafe(leader)->terrainFlags & TERRAIN_TYPE_SHOP) != 0;
     gDungeon->unk644.unk54 = isShopTile;
     gDungeon->unk644.unk55 = isShopTile;
     if (gDungeon->unk644.unk2A || gDungeon->unk644.unk50 == 0)
@@ -187,7 +187,7 @@ void sub_807EF84(void)
     val = sub_807F19C(TRUE);
     if (val != 0) {
         Tile *tile = GetTileAtEntitySafe(GetLeader());
-        if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+        if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
             if (val != 2) {
                 DisplayDungeonMessage(&dialogueInfo, gUnknown_80FE63C, 1); // This is very disappointing, please return any items before you leave.
             }
@@ -229,7 +229,7 @@ void sub_807EFFC(bool8 arg0)
                 pos.y = y;
                 pos.x = x;
                 tile = GetTile(x,y);
-                if (tile->terrainType & TERRAIN_TYPE_SHOP && tile->object != NULL && GetEntityType(tile->object) == ENTITY_ITEM) {
+                if (tile->terrainFlags & TERRAIN_TYPE_SHOP && tile->object != NULL && GetEntityType(tile->object) == ENTITY_ITEM) {
                     Item *itemPtr = GetItemInfo(tile->object);
                     if (!ItemInShop(itemPtr)) {
                         Item item = *itemPtr;
@@ -276,7 +276,7 @@ s32 sub_807F19C(bool8 arg0)
         for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
             for (y = 0; y < DUNGEON_MAX_SIZE_Y; y++) {
                 const Tile *tile = GetTile(x, y);
-                if (!(tile->terrainType & TERRAIN_TYPE_SHOP) && tile->object != NULL && GetEntityType(tile->object) == ENTITY_ITEM) {
+                if (!(tile->terrainFlags & TERRAIN_TYPE_SHOP) && tile->object != NULL && GetEntityType(tile->object) == ENTITY_ITEM) {
                     Item *itemPtr = GetItemInfo(tile->object);
                     if (IsShoppableItem(itemPtr->id)) {
                         itemPtr->flags &= ~(ITEM_FLAG_IN_SHOP);

--- a/src/dungeon_logic.c
+++ b/src/dungeon_logic.c
@@ -65,9 +65,9 @@ u8 sub_807034C(s32 id, const Tile *tile)
 
   id_s32 = SpeciesId(id);
 
-  if ((tile->monster == NULL) && ((tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) == 0)) {
+  if ((tile->monster == NULL) && ((tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) == 0)) {
       crossableTerrain = GetCrossableTerrain(id_s32);
-      tileFlags = tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+      tileFlags = tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
         switch(crossableTerrain)
         {
             case CROSSABLE_TERRAIN_LIQUID:
@@ -100,12 +100,12 @@ u8 sub_80703A0(Entity *pokemon, DungeonPos *pos)
         return TRUE;
     if (tile->monster != NULL)
         return TRUE;
-    if (tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)
+    if (tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)
         return TRUE;
 
     if ((IsCurrentFixedRoomBossFight()) || ((entityInfo->invisibleClassStatus.status != STATUS_MOBILE && (!HasHeldItem(pokemon, ITEM_MOBILE_SCARF))))) {
         crossableTerrain = GetCrossableTerrain(entityInfo->id);
-        tileFlags = tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+        tileFlags = tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
         if (IQSkillIsEnabled(pokemon, IQ_ALL_TERRAIN_HIKER)) {
             crossableTerrain = CROSSABLE_TERRAIN_CREVICE;
         }
@@ -164,14 +164,14 @@ bool8 sub_807049C(Entity *pokemon, DungeonPos *pos)
         return TRUE;
     if (pos->x >= DUNGEON_MAX_SIZE_X || pos->y >= DUNGEON_MAX_SIZE_Y)
         return TRUE;
-    if (tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)
+    if (tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)
         return TRUE;
     if (tile->monster != NULL && GetEntityType(tile->monster) != ENTITY_MONSTER)
         return TRUE;
 
     if (IsCurrentFixedRoomBossFight() || (entityInfo->invisibleClassStatus.status != STATUS_MOBILE && !HasHeldItem(pokemon, ITEM_MOBILE_SCARF))) {
         crossableTerrain = GetCrossableTerrain(entityInfo->id);
-        tileFlags = tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+        tileFlags = tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
         if (IQSkillIsEnabled(pokemon, IQ_ALL_TERRAIN_HIKER)) {
             crossableTerrain = CROSSABLE_TERRAIN_CREVICE;
         }
@@ -211,7 +211,7 @@ bool8 sub_8070564(Entity *pokemon, DungeonPos *pos)
         return TRUE;
     if (pos->x >= DUNGEON_MAX_SIZE_X || pos->y >= DUNGEON_MAX_SIZE_Y)
         return TRUE;
-    if (tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)
+    if (tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)
         return TRUE;
     if (tile->monster != NULL && GetEntityType(tile->monster) != ENTITY_MONSTER)
         return TRUE;
@@ -252,10 +252,10 @@ bool8 sub_80705F0(Entity *pokemon, DungeonPos *pos)
         return TRUE;
     if (pos->x >= DUNGEON_MAX_SIZE_X || pos->y >= DUNGEON_MAX_SIZE_Y)
         return TRUE;
-    if (((tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) == 0) && (tile->monster == NULL || (GetEntityType(tile->monster) == ENTITY_MONSTER))) {
+    if (((tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) == 0) && (tile->monster == NULL || (GetEntityType(tile->monster) == ENTITY_MONSTER))) {
         if (IsCurrentFixedRoomBossFight() || (entityInfo->invisibleClassStatus.status != STATUS_MOBILE && !HasHeldItem(pokemon, ITEM_MOBILE_SCARF))) {
             crossableTerrain = GetCrossableTerrain(entityInfo->id);
-            tileFlags = tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+            tileFlags = tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
             if (IQSkillIsEnabled(pokemon, IQ_ALL_TERRAIN_HIKER)) {
                 crossableTerrain = CROSSABLE_TERRAIN_CREVICE;
             }
@@ -292,11 +292,11 @@ bool8 sub_80706A4(Entity *pokemon, DungeonPos *pos)
         return TRUE;
     if (pos->x >= DUNGEON_MAX_SIZE_X || pos->y >= DUNGEON_MAX_SIZE_Y)
         return TRUE;
-    if ((((tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) == 0))
+    if ((((tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) == 0))
         && (tile->monster == NULL || ((GetEntityType(tile->monster) == ENTITY_MONSTER) && (GetEntInfo(tile->monster) == entityInfo)))) {
         if (IsCurrentFixedRoomBossFight() || (entityInfo->invisibleClassStatus.status != STATUS_MOBILE && !HasHeldItem(pokemon, ITEM_MOBILE_SCARF))) {
             crossableTerrain = GetCrossableTerrain(entityInfo->id);
-            tileFlags = tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+            tileFlags = tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
             if (IQSkillIsEnabled(pokemon, IQ_ALL_TERRAIN_HIKER)) {
                 crossableTerrain = CROSSABLE_TERRAIN_CREVICE;
             }
@@ -685,7 +685,7 @@ bool8 CanMoveInDirection(Entity *pokemon, u32 direction)
     const Tile *currentMapTile = GetTile(pokemon->pos.x + gAdjacentTileOffsets[direction].x,
         pokemon->pos.y + gAdjacentTileOffsets[direction].y);
 
-    if (currentMapTile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL || currentMapTile->monster != NULL)
+    if (currentMapTile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL || currentMapTile->monster != NULL)
         return FALSE;
 
     if (!IsCurrentFixedRoomBossFight())
@@ -718,7 +718,7 @@ bool8 sub_8070F3C(Entity * pokemon, DungeonPos *pos, s32 direction)
   terrain = GetCrossableTerrain(GetEntInfo(pokemon)->id);
 
   tile = GetTile(pos->x + gAdjacentTileOffsets[direction].x, pos->y + gAdjacentTileOffsets[direction].y);
-  if ((!(tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
+  if ((!(tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
      (((tile->monster == NULL || (GetEntityType(tile->monster) == ENTITY_MONSTER))))) {
     if (!IsCurrentFixedRoomBossFight())
     {
@@ -761,7 +761,7 @@ bool8 sub_8070F14(Entity * pokemon, s32 direction)
 
 
   tile = GetTile(pokemon->pos.x + gAdjacentTileOffsets[direction].x, pokemon->pos.y + gAdjacentTileOffsets[direction].y);
-  if ((!(tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
+  if ((!(tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
      (((tile->monster == NULL)))) {
 
     tile = GetTile(pokemon->pos.x, pokemon->pos.y);
@@ -781,7 +781,7 @@ bool8 sub_8070F80(Entity * pokemon, s32 direction)
   terrain = GetCrossableTerrain(GetEntInfo(pokemon)->id);
 
   tile = GetTile(pokemon->pos.x + gAdjacentTileOffsets[direction].x, pokemon->pos.y + gAdjacentTileOffsets[direction].y);
-  if ((!(tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
+  if ((!(tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
      (((tile->monster == NULL || (GetEntityType(tile->monster) == ENTITY_MONSTER))))) {
     if (!IsCurrentFixedRoomBossFight())
     {
@@ -826,7 +826,7 @@ UNUSED static bool8 sub_8071058(Entity * pokemon, s32 direction)
   terrain = GetCrossableTerrain(GetEntInfo(pokemon)->id);
 
   tile = GetTile(pokemon->pos.x + gAdjacentTileOffsets[direction].x, pokemon->pos.y + gAdjacentTileOffsets[direction].y);
-  if ((!(tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
+  if ((!(tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)) &&
      (((tile->monster == NULL || (GetEntityType(tile->monster) == ENTITY_MONSTER)) ||
       (!GetEntInfo(tile->monster)->isNotTeamMember)))) {
     if (!IsCurrentFixedRoomBossFight())
@@ -873,7 +873,7 @@ bool8 CanAttackInDirection(Entity *pokemon, s32 direction)
     }
     tile = GetTile(pokemon->pos.x + gAdjacentTileOffsets[direction].x,
         pokemon->pos.y + gAdjacentTileOffsets[direction].y);
-    if (!(tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) &&
+    if (!(tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) &&
         (tile->monster == NULL || GetEntityType(tile->monster) == ENTITY_MONSTER))
     {
         if (!IsCurrentFixedRoomBossFight())
@@ -918,11 +918,11 @@ bool8 CanAIMonsterMoveInDirection(Entity *pokemon, s32 direction, bool8 *pokemon
     *pokemonInFront = FALSE;
     frontTile = GetTile(pokemon->pos.x + gAdjacentTileOffsets[direction].x,
         pokemon->pos.y + gAdjacentTileOffsets[direction].y);
-    if (frontTile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL)
+    if (frontTile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL)
     {
         return FALSE;
     }
-    if (frontTile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE &&
+    if (frontTile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE &&
         !gDungeon->unk644.monsterHouseTriggered &&
         IQSkillIsEnabled(pokemon, IQ_HOUSE_AVOIDER))
     {
@@ -935,7 +935,7 @@ bool8 CanAIMonsterMoveInDirection(Entity *pokemon, s32 direction, bool8 *pokemon
     {
         return FALSE;
     }
-    if ((frontTile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_SECONDARY &&
+    if ((frontTile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_SECONDARY &&
         gDungeonWaterType[gDungeon->tileset] == DUNGEON_WATER_TYPE_LAVA &&
         IQSkillIsEnabled(pokemon, IQ_LAVA_EVADER))
     {

--- a/src/dungeon_main.c
+++ b/src/dungeon_main.c
@@ -821,7 +821,7 @@ static bool8 sub_805E874(void)
             return FALSE;
     }
     else {
-        if (leaderTile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
+        if (leaderTile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
             return FALSE;
     }
 
@@ -829,7 +829,7 @@ static bool8 sub_805E874(void)
         const Tile *tile = GetTile(x + gAdjacentTileOffsets[(direction + j) & 7].x, y + gAdjacentTileOffsets[(direction + j) & 7].y);
         if (tile->monster != NULL)
             return FALSE;
-        if (tile->terrainType & TERRAIN_TYPE_STAIRS)
+        if (tile->terrainFlags & TERRAIN_TYPE_STAIRS)
             return FALSE;
     }
 
@@ -1006,7 +1006,7 @@ void CheckLeaderTile(void)
     tile = GetTileAtEntitySafe(leader);
     if (IQSkillIsEnabled(leader, IQ_SUPER_MOBILE) && GetEntInfo(leader)->invisibleClassStatus.status != STATUS_MOBILE && !HasHeldItem(leader, ITEM_MOBILE_SCARF))
         sub_804AE84(&leader->pos);
-    if (tile->terrainType & TERRAIN_TYPE_STAIRS)
+    if (tile->terrainFlags & TERRAIN_TYPE_STAIRS)
         gDungeon->unk1 = 1;
 
     tileObject = tile->object;
@@ -1491,7 +1491,7 @@ static void ShowMainMenu(bool8 fromBPress, bool8 a1)
                         break;
                 }
             }
-            else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+            else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
                 SetLeaderActionToNothing(TRUE);
                 ShowDungeonStairsMenu(GetLeader());
                 if (GetLeaderActionId() != ACTION_NOTHING)

--- a/src/dungeon_map.c
+++ b/src/dungeon_map.c
@@ -169,7 +169,7 @@ void DrawMinimapTile(s32 x, s32 y)
     const Tile *tile;
     Dungeon *dungeon;
     bool8 blinded;
-    u32 terrainType;
+    u32 terrainFlags;
     bool8 hallucinating;
     bool8 showItems;
     bool8 showHiddenTraps;
@@ -210,14 +210,14 @@ void DrawMinimapTile(s32 x, s32 y)
     }
 
     tile = GetTile(x, y);
-    terrainType = GetTerrainType(tile);
+    terrainFlags = GetTerrainType(tile);
     hallucinating = gDungeon->unk181e8.hallucinating;
     blinded = gDungeon->unk181e8.blinded;
     showHiddenTraps = gDungeon->unk181e8.showInvisibleTrapsMonsters;
     showItems = gDungeon->unk181e8.showAllFloorItems;
     allTilesRevealed = gDungeon->unk181e8.allTilesRevealed;
     if (blinded) {
-        tileKnown = tile->spawnOrVisibilityFlags & VISIBILITY_FLAG_REVEALED;
+        tileKnown = tile->spawnOrVisibilityFlags.visibility & VISIBILITY_FLAG_REVEALED;
         var_24 = FALSE;
     }
     else {
@@ -225,7 +225,7 @@ void DrawMinimapTile(s32 x, s32 y)
             tileKnown = TRUE;
         }
         else {
-            tileKnown = tile->spawnOrVisibilityFlags & VISIBILITY_FLAG_REVEALED;
+            tileKnown = tile->spawnOrVisibilityFlags.visibility & VISIBILITY_FLAG_REVEALED;
         }
 
         if (GetFloorType() == FLOOR_TYPE_NORMAL) {
@@ -273,7 +273,7 @@ void DrawMinimapTile(s32 x, s32 y)
                 if (!tileKnown) {
                     mapGfxType = MAP_GFX_NOTHING;
                     if (entType == ENTITY_ITEM) {
-                        if ((showItems || (tile->spawnOrVisibilityFlags & 2)) && terrainType != TERRAIN_TYPE_WALL) {
+                        if ((showItems || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) && terrainFlags != TERRAIN_TYPE_WALL) {
                             mapGfxType = MAP_GFX_ITEM;
                         }
                     }
@@ -291,14 +291,14 @@ void DrawMinimapTile(s32 x, s32 y)
 
                 if (lookForMapObject) {
                     if (entType == ENTITY_ITEM) {
-                        if ((showItems || (tile->spawnOrVisibilityFlags & 2)) && terrainType != TERRAIN_TYPE_WALL) {
+                        if ((showItems || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) && terrainFlags != TERRAIN_TYPE_WALL) {
                             mapGfxType = MAP_GFX_ITEM;
                             lookForMapObject = FALSE;
                         }
                     }
                 }
                 if (lookForMapObject) {
-                    if (terrainType != TERRAIN_TYPE_NORMAL) {
+                    if (terrainFlags != TERRAIN_TYPE_NORMAL) {
                         mapGfxType = MAP_GFX_NOTHING;
                         lookForMapObject = FALSE;
                     }
@@ -306,7 +306,7 @@ void DrawMinimapTile(s32 x, s32 y)
             }
             else {
                 if (!tileKnown) {
-                    if (var_24 && (tile->terrainType & TERRAIN_TYPE_STAIRS)) {
+                    if (var_24 && (tile->terrainFlags & TERRAIN_TYPE_STAIRS)) {
                         if (GetFloorType() == FLOOR_TYPE_NORMAL) {
                             mapGfxType = MAP_GFX_STAIRS;
                         }
@@ -317,7 +317,7 @@ void DrawMinimapTile(s32 x, s32 y)
                     }
                 }
                 else {
-                    if ((tile->terrainType & TERRAIN_TYPE_STAIRS)) {
+                    if ((tile->terrainFlags & TERRAIN_TYPE_STAIRS)) {
                         if (GetFloorType() == FLOOR_TYPE_NORMAL) {
                             mapGfxType = MAP_GFX_STAIRS;
                         }
@@ -340,7 +340,7 @@ void DrawMinimapTile(s32 x, s32 y)
             if (!tileKnown) {
                 mapGfxType = 1;
             }
-            else if (terrainType != TERRAIN_TYPE_NORMAL) {
+            else if (terrainFlags != TERRAIN_TYPE_NORMAL) {
                 mapGfxType = 1;
             }
             else {
@@ -371,7 +371,7 @@ void DrawMinimapTile(s32 x, s32 y)
                 }
 
                 mapGfxType = (s16) terrainLine;
-                if (tile->spawnOrVisibilityFlags & VISIBILITY_FLAG_VISITED) {
+                if (tile->spawnOrVisibilityFlags.visibility & VISIBILITY_FLAG_VISITED) {
                     mapGfxType = (s16) (mapGfxType + MAP_GFX_TERRAIN_TILES_VISITED);
                 }
                 else {

--- a/src/dungeon_map.c
+++ b/src/dungeon_map.c
@@ -169,7 +169,7 @@ void DrawMinimapTile(s32 x, s32 y)
     const Tile *tile;
     Dungeon *dungeon;
     bool8 blinded;
-    u32 terrainFlags;
+    u32 terrainType;
     bool8 hallucinating;
     bool8 showItems;
     bool8 showHiddenTraps;
@@ -210,7 +210,7 @@ void DrawMinimapTile(s32 x, s32 y)
     }
 
     tile = GetTile(x, y);
-    terrainFlags = GetTerrainType(tile);
+    terrainType = GetTerrainType(tile);
     hallucinating = gDungeon->unk181e8.hallucinating;
     blinded = gDungeon->unk181e8.blinded;
     showHiddenTraps = gDungeon->unk181e8.showInvisibleTrapsMonsters;
@@ -273,7 +273,7 @@ void DrawMinimapTile(s32 x, s32 y)
                 if (!tileKnown) {
                     mapGfxType = MAP_GFX_NOTHING;
                     if (entType == ENTITY_ITEM) {
-                        if ((showItems || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) && terrainFlags != TERRAIN_TYPE_WALL) {
+                        if ((showItems || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) && terrainType != TERRAIN_TYPE_WALL) {
                             mapGfxType = MAP_GFX_ITEM;
                         }
                     }
@@ -291,14 +291,14 @@ void DrawMinimapTile(s32 x, s32 y)
 
                 if (lookForMapObject) {
                     if (entType == ENTITY_ITEM) {
-                        if ((showItems || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) && terrainFlags != TERRAIN_TYPE_WALL) {
+                        if ((showItems || (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_ITEM)) && terrainType != TERRAIN_TYPE_WALL) {
                             mapGfxType = MAP_GFX_ITEM;
                             lookForMapObject = FALSE;
                         }
                     }
                 }
                 if (lookForMapObject) {
-                    if (terrainFlags != TERRAIN_TYPE_NORMAL) {
+                    if (terrainType != TERRAIN_TYPE_NORMAL) {
                         mapGfxType = MAP_GFX_NOTHING;
                         lookForMapObject = FALSE;
                     }
@@ -340,7 +340,7 @@ void DrawMinimapTile(s32 x, s32 y)
             if (!tileKnown) {
                 mapGfxType = 1;
             }
-            else if (terrainFlags != TERRAIN_TYPE_NORMAL) {
+            else if (terrainType != TERRAIN_TYPE_NORMAL) {
                 mapGfxType = 1;
             }
             else {

--- a/src/dungeon_map_access.c
+++ b/src/dungeon_map_access.c
@@ -183,7 +183,7 @@ void sub_80498A8(s32 x,s32 y)
     return;
   }
   r7 = 0;
-  sp_0x20 = GetTile(x, y)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+  sp_0x20 = GetTile(x, y)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
   if (gDungeon->tileset >= 0x40) {
     if ((0x17 >= x) && (0x17 >= y)) {
         GetTileMut(x,y)->unk8 = gDungeon->unk12C24[y * 0x18 + x];
@@ -194,14 +194,14 @@ void sub_80498A8(s32 x,s32 y)
   }
   else
   {
-    sp_0x0 = GetTile(x,y + 1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    sp_0x4 = GetTile(x + 1,y + 1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    sp_0x8 = GetTile(x + 1,y)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    sp_0xC = GetTile(x + 1,y -1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    sp_0x10 = GetTile(x, y -1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    sp_0x14 = GetTile(x - 1,y -1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    sp_0x18 = GetTile(x - 1, y)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    r1 =  GetTile(x - 1,y + 1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0x0 = GetTile(x,y + 1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0x4 = GetTile(x + 1,y + 1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0x8 = GetTile(x + 1,y)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0xC = GetTile(x + 1,y -1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0x10 = GetTile(x, y -1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0x14 = GetTile(x - 1,y -1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    sp_0x18 = GetTile(x - 1, y)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    r1 =  GetTile(x - 1,y + 1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
     sp_0x1C = r1;
     if (sp_0x20 == 1) {
       r7 = 0xFF;
@@ -351,15 +351,15 @@ void sub_8049BB0(s32 x, s32 y)
     flags[2] = 0;
     flags[3] = 0;
 
-    terrainFlags = GetTile(x,   y+1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    terrainFlags = GetTile(x,   y+1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
     var_4C[0] = terrainFlags;
-    var_4C[1] = GetTile(x+1, y+1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    var_4C[2] = GetTile(x+1, y)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    var_4C[3] = GetTile(x+1, y-1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    var_4C[4] = GetTile(x,   y-1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    var_4C[5] = GetTile(x-1, y-1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    var_4C[6] = GetTile(x-1, y)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
-    var_4C[7] = GetTile(x-1, y+1)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[1] = GetTile(x+1, y+1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[2] = GetTile(x+1, y)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[3] = GetTile(x+1, y-1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[4] = GetTile(x,   y-1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[5] = GetTile(x-1, y-1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[6] = GetTile(x-1, y)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
+    var_4C[7] = GetTile(x-1, y+1)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY);
 
     if (var_4C[0] == TERRAIN_TYPE_NORMAL)
         flags[CROSSABLE_TERRAIN_REGULAR] |= 1;
@@ -503,16 +503,16 @@ void UpdateTrapsVisibility(void)
         var_44 = gUnknown_80F6C06[30 + y];
         r7 = r10 + (r8 * 3);
         tile = GetTile(var_48, var_44);
-        if (tile->terrainType & TERRAIN_TYPE_UNK_x1000) {
+        if (tile->terrainFlags & TERRAIN_TYPE_UNK_x1000) {
             src = &dungeon->unk12A18[26][r7];
         }
-        else if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+        else if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
             src = &dungeon->unk12A18[25][r7];
         }
         else if (hallucinating) {
             src = &dungeon->unk11884[tile->unk8][r7];
         }
-        else if (tile->spawnOrVisibilityFlags & 4) {
+        else if (tile->spawnOrVisibilityFlags.visibility & 4) {
             src = &dungeon->unk12A18[27][r7];
         }
         else
@@ -527,7 +527,7 @@ void UpdateTrapsVisibility(void)
                     src = &dungeon->unk11884[tile->unk8][r7];
                 }
             }
-            else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+            else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
                 src = &dungeon->unk12A18[dungeon->unk3A12][r7];
             }
             else {
@@ -548,16 +548,16 @@ void UpdateTrapsVisibility(void)
                 var_44++;
                 r7 = r10;
                 tile = GetTile(var_48, var_44);
-                if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+                if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
                     src = &dungeon->unk12A18[25][r7];
                 }
-                else if (tile->terrainType & TERRAIN_TYPE_UNK_x1000) {
+                else if (tile->terrainFlags & TERRAIN_TYPE_UNK_x1000) {
                     src = &dungeon->unk12A18[26][r7];
                 }
                 else if (hallucinating) {
                     src = &dungeon->unk11884[tile->unk8][r7];
                 }
-                else if (tile->spawnOrVisibilityFlags & 4) {
+                else if (tile->spawnOrVisibilityFlags.visibility & 4) {
                     src = &dungeon->unk12A18[27][r7];
                 }
                 else
@@ -572,7 +572,7 @@ void UpdateTrapsVisibility(void)
                             src = &dungeon->unk11884[tile->unk8][r7];
                         }
                     }
-                    else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+                    else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
                         src = &dungeon->unk12A18[dungeon->unk3A12][r7];
                     }
                     else {
@@ -621,10 +621,10 @@ void sub_804A1F0(s32 a0, s32 a1)
     r10 = gUnknown_80F6C06[30 + y];
     r6 = var_28 + r8 * 3;
     tile = GetTile(var_2C, r10);
-    if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+    if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
         src = &dungeon->unk12A18[25][r6];
     }
-    else if (tile->terrainType & TERRAIN_TYPE_UNK_x1000) {
+    else if (tile->terrainFlags & TERRAIN_TYPE_UNK_x1000) {
         src = &dungeon->unk12A18[26][r6];
     }
     else if (hallucinating) {
@@ -642,7 +642,7 @@ void sub_804A1F0(s32 a0, s32 a1)
                 src = &dungeon->unk11884[tile->unk8][r6];
             }
         }
-        else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+        else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
             src = &dungeon->unk12A18[dungeon->unk3A12][r6];
         }
         else {
@@ -662,10 +662,10 @@ void sub_804A1F0(s32 a0, s32 a1)
             r10++;
             r6 = var_28;
             tile = GetTile(var_2C, r10);
-            if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+            if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
                 src = &dungeon->unk12A18[25][r6];
             }
-            else if (tile->terrainType & TERRAIN_TYPE_UNK_x1000) {
+            else if (tile->terrainFlags & TERRAIN_TYPE_UNK_x1000) {
                 src = &dungeon->unk12A18[26][r6];
             }
             else if (hallucinating) {
@@ -683,7 +683,7 @@ void sub_804A1F0(s32 a0, s32 a1)
                         src = &dungeon->unk11884[tile->unk8][r6];
                     }
                 }
-                else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+                else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
                     src = &dungeon->unk12A18[dungeon->unk3A12][r6];
                 }
                 else {
@@ -722,10 +722,10 @@ void sub_804A49C(s32 a0, s32 a1)
     var_2C = gUnknown_80F6C06[30 + y];
     r6 = r9 + var_28 * 3;
     tile = GetTile(r10, var_2C);
-    if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+    if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
         src = &dungeon->unk12A18[25][r6];
     }
-    else if (tile->terrainType & TERRAIN_TYPE_UNK_x1000) {
+    else if (tile->terrainFlags & TERRAIN_TYPE_UNK_x1000) {
         src = &dungeon->unk12A18[26][r6];
     }
     else if (hallucinating) {
@@ -743,7 +743,7 @@ void sub_804A49C(s32 a0, s32 a1)
                 src = &dungeon->unk11884[tile->unk8][r6];
             }
         }
-        else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+        else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
             src = &dungeon->unk12A18[dungeon->unk3A12][r6];
         }
         else {
@@ -763,10 +763,10 @@ void sub_804A49C(s32 a0, s32 a1)
             r10++;
             r6 = var_28 * 3;
             tile = GetTile(r10, var_2C);
-            if (tile->terrainType & TERRAIN_TYPE_SHOP) {
+            if (tile->terrainFlags & TERRAIN_TYPE_SHOP) {
                 src = &dungeon->unk12A18[25][r6];
             }
-            else if (tile->terrainType & TERRAIN_TYPE_UNK_x1000) {
+            else if (tile->terrainFlags & TERRAIN_TYPE_UNK_x1000) {
                 src = &dungeon->unk12A18[26][r6];
             }
             else if (hallucinating) {
@@ -784,7 +784,7 @@ void sub_804A49C(s32 a0, s32 a1)
                         src = &dungeon->unk11884[tile->unk8][r6];
                     }
                 }
-                else if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+                else if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
                     src = &dungeon->unk12A18[dungeon->unk3A12][r6];
                 }
                 else {
@@ -945,7 +945,7 @@ void sub_804AAAC(void)
         for(x = 0; x < DUNGEON_MAX_SIZE_X; x++)
         {
             tile = GetTileMut(x,y);
-            tile->spawnOrVisibilityFlags = 0;
+            tile->spawnOrVisibilityFlags.visibility = 0;
         }
     }
 }
@@ -1057,7 +1057,7 @@ void DiscoverMinimap(DungeonPos *pos)
         for (y = yMin; y <= yMax; y++) {
             for (x = xMin; x <= xMax; x++) {
                 tile = GetTileMut(x,y);
-                tile->spawnOrVisibilityFlags |= 3;
+                tile->spawnOrVisibilityFlags.visibility |= (VISIBILITY_FLAG_REVEALED | VISIBILITY_FLAG_VISITED);
                 DrawMinimapTile(x,y);
             }
         }
@@ -1101,10 +1101,10 @@ bool8 sub_804AD34(DungeonPos *pos)
 
   iVar8 = 0;
   tile = GetTileMut(pos->x,pos->y);
-  if (!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
-    if(!(tile->terrainType & (TERRAIN_TYPE_UNBREAKABLE | TERRAIN_TYPE_IMPASSABLE_WALL))){
+  if (!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+    if(!(tile->terrainFlags & (TERRAIN_TYPE_UNBREAKABLE | TERRAIN_TYPE_IMPASSABLE_WALL))){
     iVar8 = 1;
-    tile->terrainType = (tile->terrainType & ~(TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) | TERRAIN_TYPE_NORMAL;
+    tile->terrainFlags = (tile->terrainFlags & ~(TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) | TERRAIN_TYPE_NORMAL;
 
     for(y = -1; y < 2; y++)
     {
@@ -1140,11 +1140,11 @@ bool8 sub_804AE08(DungeonPos *pos)
   uVar6 = FALSE;
   tile = GetTileMut(pos->x,pos->y);
 
-  if (!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
-    if(!(tile->terrainType & (TERRAIN_TYPE_UNBREAKABLE | TERRAIN_TYPE_IMPASSABLE_WALL))) {
+  if (!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+    if(!(tile->terrainFlags & (TERRAIN_TYPE_UNBREAKABLE | TERRAIN_TYPE_IMPASSABLE_WALL))) {
         uVar6 = TRUE;
-        tile->terrainType = (tile->terrainType & ~(TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) | TERRAIN_TYPE_NORMAL;
-        tile->spawnOrVisibilityFlags = tile->spawnOrVisibilityFlags | 0x10;
+        tile->terrainFlags = (tile->terrainFlags & ~(TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) | TERRAIN_TYPE_NORMAL;
+        tile->spawnOrVisibilityFlags.visibility = tile->spawnOrVisibilityFlags.visibility | 0x10;
 
         for(y = -1; y < 2; y++)
         {
@@ -1166,8 +1166,8 @@ void sub_804AE84(DungeonPos *pos)
   s32 y;
 
   tile = GetTileMut(pos->x,pos->y);
-  if ((tile->spawnOrVisibilityFlags & 0x10) != 0) {
-    tile->spawnOrVisibilityFlags &= 0xffef;
+  if ((tile->spawnOrVisibilityFlags.visibility & 0x10) != 0) {
+    tile->spawnOrVisibilityFlags.visibility &= 0xffef;
 
     for(y = -1; y < 2; y++)
     {
@@ -1195,12 +1195,12 @@ bool8 IsTileGround(Tile *tile)
     bool8 isGround = FALSE;
     if (IsWaterTileset())
     {
-        if (!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+        if (!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
         {
             isGround = TRUE;
         }
     }
-    else if ((tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_SECONDARY ||
+    else if ((tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_SECONDARY ||
         gDungeonWaterType[gDungeon->tileset] == DUNGEON_WATER_TYPE_LAVA)
     {
         isGround = TRUE;

--- a/src/dungeon_misc.c
+++ b/src/dungeon_misc.c
@@ -1453,13 +1453,13 @@ static bool8 sub_806A5A4(s16 r0)
 
 void sub_806A5B8(Entity *entity)
 {
-    s32 terrainFlags;
+    s32 terrainType;
 
     if (!EntityIsValid(entity))
         return;
 
-    terrainFlags = GetTerrainType(GetTileAtEntitySafe(entity));
-    if (terrainFlags == TERRAIN_TYPE_SECONDARY) {
+    terrainType = GetTerrainType(GetTileAtEntitySafe(entity));
+    if (terrainType == TERRAIN_TYPE_SECONDARY) {
         EntityInfo *info = GetEntInfo(entity);
         // If lava - defrost and burn
         if (gDungeonWaterType[gDungeon->tileset] == DUNGEON_WATER_TYPE_LAVA) {
@@ -1482,7 +1482,7 @@ void sub_806A5B8(Entity *entity)
         }
     }
     // If wall - decrement belly by 5
-    else if (terrainFlags == TERRAIN_TYPE_WALL) {
+    else if (terrainType == TERRAIN_TYPE_WALL) {
         const u8 *str;
         EntityInfo *info = GetEntInfo(entity);
 

--- a/src/dungeon_misc.c
+++ b/src/dungeon_misc.c
@@ -470,7 +470,7 @@ void sub_8068F80(void)
     dungeon->unk644.unk2F = 0;
     dungeon->unkC0.type = ENTITY_NOTHING;
     if (leader != NULL) {
-        bool8 isShop = (GetTileAtEntitySafe(leader)->terrainType & TERRAIN_TYPE_SHOP) != 0;
+        bool8 isShop = (GetTileAtEntitySafe(leader)->terrainFlags & TERRAIN_TYPE_SHOP) != 0;
         dungeon->unk644.unk54 = isShop;
         dungeon->unk644.unk55 = isShop;
         DiscoverMinimap(&leader->pos);
@@ -1453,13 +1453,13 @@ static bool8 sub_806A5A4(s16 r0)
 
 void sub_806A5B8(Entity *entity)
 {
-    s32 terrainType;
+    s32 terrainFlags;
 
     if (!EntityIsValid(entity))
         return;
 
-    terrainType = GetTerrainType(GetTileAtEntitySafe(entity));
-    if (terrainType == TERRAIN_TYPE_SECONDARY) {
+    terrainFlags = GetTerrainType(GetTileAtEntitySafe(entity));
+    if (terrainFlags == TERRAIN_TYPE_SECONDARY) {
         EntityInfo *info = GetEntInfo(entity);
         // If lava - defrost and burn
         if (gDungeonWaterType[gDungeon->tileset] == DUNGEON_WATER_TYPE_LAVA) {
@@ -1482,7 +1482,7 @@ void sub_806A5B8(Entity *entity)
         }
     }
     // If wall - decrement belly by 5
-    else if (terrainType == TERRAIN_TYPE_WALL) {
+    else if (terrainFlags == TERRAIN_TYPE_WALL) {
         const u8 *str;
         EntityInfo *info = GetEntInfo(entity);
 

--- a/src/dungeon_move_util.c
+++ b/src/dungeon_move_util.c
@@ -634,7 +634,7 @@ void sub_80566F8(Entity *attacker, Move *move, s32 a2, bool8 a3, s32 itemId, s32
         var_68.y += var_48;
         someCount++;
         tile = GetTile(var_68.x, var_68.y);
-        if (!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+        if (!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
             break;
         if (tile->monster != NULL && GetEntityType(tile->monster) == ENTITY_MONSTER)
             break;
@@ -713,7 +713,7 @@ void sub_80566F8(Entity *attacker, Move *move, s32 a2, bool8 a3, s32 itemId, s32
         }
 
         tile = GetTile(var_68.x, var_68.y);
-        if (!(tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
+        if (!(tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)))
             break;
         if (tile->monster != NULL && GetEntityType(tile->monster) == ENTITY_MONSTER && !sub_80571F0(tile->monster, move)) {
             if (targetArrId <= 0) {

--- a/src/dungeon_range.c
+++ b/src/dungeon_range.c
@@ -185,7 +185,7 @@ bool8 IsTargetTwoTilesAway(DungeonPos *pos1, DungeonPos *pos2)
                 y1--;
             }
             tile = GetTile(x1, y1);
-            if ((tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == 0)
+            if ((tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == 0)
             {
                 return FALSE;
             }
@@ -213,7 +213,7 @@ bool8 IsTargetTwoTilesAway(DungeonPos *pos1, DungeonPos *pos2)
                 y2 = y2 - 1;
             }
             tile = GetTile(x2, y2);
-            if ((tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == 0)
+            if ((tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == 0)
             {
                 return FALSE;
             }
@@ -362,7 +362,7 @@ bool8 sub_808384C(DungeonPos *posDst, const DungeonPos *posSrc)
         x = gUnknown_80F4468[i].x + posSrc->x;
         y = gUnknown_80F4468[i].y + posSrc->y;
         tile = GetTile(x, y);
-        if (!(tile->terrainType & TERRAIN_TYPE_UNK_x800)
+        if (!(tile->terrainFlags & TERRAIN_TYPE_UNK_x800)
             && GetTerrainType(tile) == TERRAIN_TYPE_NORMAL
             && tile->object == NULL
             && tile->monster == NULL)

--- a/src/dungeon_serializer.c
+++ b/src/dungeon_serializer.c
@@ -688,8 +688,8 @@ static void WriteIQSkills(DataSerializer *seri, IqSkillFlags *src)
 
 static void WriteTile(DataSerializer *seri, Tile *src)
 {
-    WriteU16(seri, src->terrainType);
-    WriteU16(seri, src->spawnOrVisibilityFlags);
+    WriteU16(seri, src->terrainFlags);
+    WriteU16(seri, src->spawnOrVisibilityFlags.visibility);
     WriteBytes(seri, &src->room, 1);
     WriteBytes(seri, &src->unkE, 1);
 }
@@ -805,8 +805,8 @@ static void ReadTile(DataSerializer *seri, Tile *dst)
 {
     memset(dst, 0, sizeof(Tile));
 
-    dst->terrainType = ReadU16(seri);
-    dst->spawnOrVisibilityFlags = ReadU16(seri);
+    dst->terrainFlags = ReadU16(seri);
+    dst->spawnOrVisibilityFlags.visibility = ReadU16(seri);
 
     ReadBytes(seri, &dst->room, 1);
     ReadBytes(seri, &dst->unkE, 1);

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -713,7 +713,7 @@ void HandleLuminousOrbAction(Entity *pokemon)
     for(XCoord = 0; XCoord < DUNGEON_MAX_SIZE_X; XCoord++)
     {
       Tile *mapTile = GetTileMut(XCoord, YCoord);
-      mapTile->spawnOrVisibilityFlags |= VISIBILITY_FLAG_REVEALED;
+      mapTile->spawnOrVisibilityFlags.visibility |= VISIBILITY_FLAG_REVEALED;
     }
   }
   UpdateCamera(0);

--- a/src/dungeon_util.c
+++ b/src/dungeon_util.c
@@ -366,7 +366,7 @@ Entity *SpawnItemEntity(DungeonPos *pos)
     Entity *ent;
 
     if (gDungeonWaterType[gDungeon->tileset] == DUNGEON_WATER_TYPE_LAVA
-        && (GetTileMut(pos->x, pos->y)->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_SECONDARY) {
+        && (GetTileMut(pos->x, pos->y)->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_SECONDARY) {
         return NULL;
     }
 

--- a/src/explosion.c
+++ b/src/explosion.c
@@ -126,7 +126,7 @@ void HandleExplosion(Entity *pokemon,Entity *target,DungeonPos *param_3,s32 para
                     tile = GetTileMut(pos.x,pos.y);
                     if ((0 < pos.x) && (0 < pos.y && ((pos.x < (DUNGEON_MAX_SIZE_X - 1) && ((pos.y < (DUNGEON_MAX_SIZE_Y - 1)
                         && GetTerrainType(tile) == TERRAIN_TYPE_WALL)))
-                    )) && (tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) == 0) {
+                    )) && (tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) == 0) {
                         SetTerrainNormal(tile);
                         for(y = -1; y < 2; y++)
                         {

--- a/src/move_checks.c
+++ b/src/move_checks.c
@@ -273,7 +273,7 @@ bool8 CanUseOnSelfWithStatusChecker(Entity *pokemon, Move *move)
         case MOVE_DIG:
         {
             Tile *tile = GetTileAtEntitySafe(pokemon);
-            if (!IsTileGround(tile) || (tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_NORMAL)
+            if (!IsTileGround(tile) || (tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_NORMAL)
             {
                 return FALSE;
             }

--- a/src/move_orb_actions_1.c
+++ b/src/move_orb_actions_1.c
@@ -131,7 +131,7 @@ bool8 DigMoveAction(Entity * pokemon, Entity * target, Move *move, s32 param_4)
 
     flag = FALSE;
     tile = GetTileAtEntitySafe(pokemon);
-    if ((!IsTileGround(tile)) || ((tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != 1)) {
+    if ((!IsTileGround(tile)) || ((tile->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != 1)) {
         TryDisplayDungeonLoggableMessage3(pokemon,target,gUnknown_80FD14C); // It can only be used on land!
     }
     else {

--- a/src/move_orb_actions_5.c
+++ b/src/move_orb_actions_5.c
@@ -44,8 +44,8 @@ bool8 FillInOrbAction(Entity *pokemon,Entity *target, Move *move, s32 param_4)
 
         sub_8042A54(&tileCoords);
         tileToFill = GetTileMut(tileCoords.x,tileCoords.y);
-        if ((tileToFill->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_SECONDARY) {
-            tileToFill->terrainType = (tileToFill->terrainType & ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) | TERRAIN_TYPE_NORMAL;
+        if ((tileToFill->terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) == TERRAIN_TYPE_SECONDARY) {
+            tileToFill->terrainFlags = (tileToFill->terrainFlags & ~(TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) | TERRAIN_TYPE_NORMAL;
 
             for(y = -1; y < 2; y++)
                 for(x = -1; x < 2; x++)

--- a/src/move_orb_effects_1.c
+++ b/src/move_orb_effects_1.c
@@ -401,7 +401,7 @@ void BurnedStatusTarget(Entity * pokemon, Entity * target, u8 param_3, bool8 dis
       else
       {
         tile_1 = GetTileAtEntitySafe(target);
-        if (((tile_1->terrainType & (TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) == TERRAIN_TYPE_SECONDARY) &&
+        if (((tile_1->terrainFlags & (TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) == TERRAIN_TYPE_SECONDARY) &&
            (gDungeonWaterType[gDungeon->tileset] != DUNGEON_WATER_TYPE_LAVA)) {
                 if (displayMessage)
                     TryDisplayDungeonLoggableMessage3(pokemon,target,gUnknown_80FEBBC);
@@ -656,7 +656,7 @@ void FrozenStatusTarget(Entity * pokemon, Entity * target, bool8 displayMessage)
       else
       {
         tile = GetTileAtEntitySafe(target);
-        if (((tile->terrainType & (TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) == TERRAIN_TYPE_SECONDARY) &&
+        if (((tile->terrainFlags & (TERRAIN_TYPE_SECONDARY | TERRAIN_TYPE_NORMAL)) == TERRAIN_TYPE_SECONDARY) &&
            (gDungeonWaterType[gDungeon->tileset] == DUNGEON_WATER_TYPE_LAVA)) {
                 if (displayMessage)
                     TryDisplayDungeonLoggableMessage3(pokemon,target,gUnknown_80FCE34);

--- a/src/one_room_orb.c
+++ b/src/one_room_orb.c
@@ -58,14 +58,14 @@ void HandleOneRoomOrb(Entity *pokemon, Entity *target)
 		{
 			bVar1 = 0;
 			tile = GetTileMut(x,y);
-			tile->terrainType &= ~(TERRAIN_TYPE_UNK_x400);
+			tile->terrainFlags &= ~(TERRAIN_TYPE_UNK_x400);
 			tile->room = 0;
-			if ((tile->terrainType & TERRAIN_TYPE_IMPASSABLE_WALL) == 0)
+			if ((tile->terrainFlags & TERRAIN_TYPE_IMPASSABLE_WALL) == 0)
 			{
-				if((tile->terrainType & TERRAIN_TYPE_UNBREAKABLE) == 0) {
-					tile->spawnOrVisibilityFlags |= SPAWN_FLAG_STAIRS | SPAWN_FLAG_ITEM;
-					tile->terrainType &= ~(TERRAIN_TYPE_NATURAL_JUNCTION);
-					if ((tile->terrainType & TERRAIN_TYPE_IN_MONSTER_HOUSE)) {
+				if((tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE) == 0) {
+					tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_STAIRS | SPAWN_FLAG_ITEM;
+					tile->terrainFlags &= ~(TERRAIN_TYPE_NATURAL_JUNCTION);
+					if ((tile->terrainFlags & TERRAIN_TYPE_IN_MONSTER_HOUSE)) {
 						isMonsterHouse = TRUE;
 					}
 					if (GetTerrainType(tile) != TERRAIN_TYPE_SECONDARY)
@@ -80,7 +80,7 @@ void HandleOneRoomOrb(Entity *pokemon, Entity *target)
 							else {
 								if (GetTerrainType(tile) == TERRAIN_TYPE_NORMAL) continue;
 								SetTerrainNormal(tile);
-								tile->terrainType |= TERRAIN_TYPE_UNK_x400;
+								tile->terrainFlags |= TERRAIN_TYPE_UNK_x400;
 							}
 						}
 				}
@@ -95,8 +95,8 @@ void HandleOneRoomOrb(Entity *pokemon, Entity *target)
 			for(y = 0; y < DUNGEON_MAX_SIZE_Y; y++)
 			{
 				tile = GetTileMut(x,y);
-				if (!(tile->terrainType & TERRAIN_TYPE_UNBREAKABLE))
-					if(((tile->terrainType & (TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS| TERRAIN_TYPE_UNK_x400)) == (TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS| TERRAIN_TYPE_UNK_x400))) {
+				if (!(tile->terrainFlags & TERRAIN_TYPE_UNBREAKABLE))
+					if(((tile->terrainFlags & (TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS| TERRAIN_TYPE_UNK_x400)) == (TERRAIN_TYPE_UNREACHABLE_FROM_STAIRS| TERRAIN_TYPE_UNK_x400))) {
 						SetTerrainSecondary(tile);
 					}
 			}
@@ -111,7 +111,7 @@ void HandleOneRoomOrb(Entity *pokemon, Entity *target)
 		for(y = 0; y < DUNGEON_MAX_SIZE_Y; y++)
 		{
 			if (isMonsterHouse) {
-				GetTileMut(x,y)->terrainType |= TERRAIN_TYPE_IN_MONSTER_HOUSE;
+				GetTileMut(x,y)->terrainFlags |= TERRAIN_TYPE_IN_MONSTER_HOUSE;
 			}
 			sub_8049BB0(x,y);
 		}

--- a/src/trap.c
+++ b/src/trap.c
@@ -56,11 +56,11 @@ void sub_807FA18(void)
         for (x = 0; x < DUNGEON_MAX_SIZE_X; x++) {
             Tile *tile = GetTileMut(x, y);
 
-            if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_TRAP) {
+            if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_TRAP) {
                 s32 trapId;
                 DungeonPos pos = {x, y};
 
-                if (tile->spawnOrVisibilityFlags & SPAWN_FLAG_UNK6) {
+                if (tile->spawnOrVisibilityFlags.spawn & SPAWN_FLAG_UNK6) {
                     trapId = TRAP_WARP_TRAP;
                 }
                 else {
@@ -99,7 +99,7 @@ void sub_807FA9C(void)
             if (tile->object != NULL && GetEntityType(tile->object) == ENTITY_TRAP && (tile->object->isVisible || showInvisibles)) {
                 r6 = TRUE;
             }
-            if (tile->terrainType & TERRAIN_TYPE_STAIRS) {
+            if (tile->terrainFlags & TERRAIN_TYPE_STAIRS) {
                 r6 = TRUE;
             }
 
@@ -133,21 +133,28 @@ void sub_807FC3C(DungeonPos *pos, u32 trapID, u32 param_3)
 bool8 CanLayTrap(DungeonPos *pos)
 {
     Tile *tile = GetTileMut(pos->x, pos->y);
-    if (tile->terrainType & TERRAIN_TYPE_STAIRS ||
-        tile->room == CORRIDOR_ROOM ||
-        tile->terrainType & TERRAIN_TYPE_NATURAL_JUNCTION)
-    {
+    if (tile->terrainFlags & TERRAIN_TYPE_STAIRS)
         return FALSE;
-    }
-    if (tile->terrainType & TERRAIN_TYPE_SHOP)
-    {
+
+    if (tile->room == CORRIDOR_ROOM)
         return FALSE;
-    }
-    if ((tile->terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_NORMAL ||
-        (tile->object != NULL && GetEntityType(tile->object) != ENTITY_TRAP))
-    {
+
+    if (tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION)
         return FALSE;
+
+    if (tile->terrainFlags & TERRAIN_TYPE_SHOP)
+        return FALSE;
+
+    if (GetTerrainType(tile) != TERRAIN_TYPE_NORMAL)
+        return FALSE;
+
+    if (tile->object != NULL) {
+        if (GetEntityType(tile->object) != ENTITY_TRAP)
+            return FALSE;
+        else
+            return TRUE;
     }
+
     return TRUE;
 }
 
@@ -156,7 +163,7 @@ bool8 LayTrap(DungeonPos *pos, u8 trapID, u8 param_3)
     Tile *tile;
     Entity *entity;
     int counter;
-    u16 terrainType;
+    u16 terrainFlags;
 
     tile = GetTileMut(pos->x, pos->y);
     if (TRAP_SPIKE_TRAP < trapID) {
@@ -168,12 +175,12 @@ bool8 LayTrap(DungeonPos *pos, u8 trapID, u8 param_3)
             trapID = TRAP_CHESTNUT_TRAP;
         }
     }
-    terrainType = tile->terrainType;
-    if ((terrainType & TERRAIN_TYPE_STAIRS) != 0) goto _0807FD6E;
+    terrainFlags = tile->terrainFlags;
+    if ((terrainFlags & TERRAIN_TYPE_STAIRS) != 0) goto _0807FD6E;
     if (tile->room == CORRIDOR_ROOM) goto _0807FD6E;
-    if ((terrainType & TERRAIN_TYPE_NATURAL_JUNCTION) != 0) goto _0807FD6E;
-    if ((terrainType & TERRAIN_TYPE_SHOP) != 0) goto _0807FD6E;
-    if (((terrainType & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_NORMAL)) goto _0807FD6E;
+    if ((terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION) != 0) goto _0807FD6E;
+    if ((terrainFlags & TERRAIN_TYPE_SHOP) != 0) goto _0807FD6E;
+    if (((terrainFlags & (TERRAIN_TYPE_NORMAL | TERRAIN_TYPE_SECONDARY)) != TERRAIN_TYPE_NORMAL)) goto _0807FD6E;
     if (tile->object != NULL) {
         if (GetEntityType(tile->object) != ENTITY_TRAP) goto _0807FD6E;
         GetTrapInfo(tile->object)->id = trapID;

--- a/src/trawl_orb.c
+++ b/src/trawl_orb.c
@@ -100,7 +100,7 @@ void HandleTrawlOrbAction(Entity *user, Entity *target)
                     pos.y = user->pos.y + gUnknown_80F4468[j].y;
 
                     tile = GetTile(pos.x, pos.y);
-                    if (GetTerrainType(tile) == TERRAIN_TYPE_NORMAL && !(tile->terrainType & TERRAIN_TYPE_STAIRS) && tile->object == NULL) {
+                    if (GetTerrainType(tile) == TERRAIN_TYPE_NORMAL && !(tile->terrainFlags & TERRAIN_TYPE_STAIRS) && tile->object == NULL) {
                         targetTilePos[i] = pos;
                         targetTileUsed[j] = TRUE;
                         foundTile = TRUE;


### PR DESCRIPTION
Now the struct has different size depending on game version.
Also renamed `terrainType` to `terrainFlags` and slightly modified `CanLayTrap` so that it'd match Blue/Sky asm as well.