### PR TITLE
update member names of FloorProperties struct

### DIFF
--- a/include/structs/str_dungeon.h
+++ b/include/structs/str_dungeon.h
@@ -121,9 +121,9 @@ typedef struct FloorProperties
 {
     u8 layout;
     s8 roomDensity;
-    u8 unk2;
-    u8 unk3;
-    u8 unk4;
+    u8 tileset;
+    u8 bgMusic;
+    u8 weather; // See include/constants/weather.h
     u8 floorConnectivity;
     u8 enemyDensity;
     u8 kecleonShopChance; // Percentage chance 0-100%
@@ -133,19 +133,20 @@ typedef struct FloorProperties
     bool8 allowDeadEnds;
     u8 secondaryStructuresBudget; // Maximum number of secondary structures that can be generated
     u8 roomFlags; // See ROOM_FLAG_
-    u8 unkE;
+    bool8 unkE; // Unreferenced flag
     u8 itemDensity;
     u8 trapDensity;
-    u8 unk11;
-    u8 unk12;
+    u8 floorNumber; // Unreferenced
+    u8 fixedRoomNumber;
     u8 numExtraHallways;
     u8 buriedItemDensity; // Density of buried items (in walls)
-    u8 unk15;
-    u8 unk16;
-    u8 unk17;
-    u8 unk18;
-    u8 itemlessMonsterHouseChance; // Chance that a monster house will be itemless
-    u8 unk1A;
+    u8 unk15; // Unreferenced
+    u8 visibilityRange;
+    u8 moneyUpperBound; // Generated money stacks cannot exceed this amount (multiplied by 40)
+    u8 kecleonShopLayout;
+    u8 itemlessMonsterHouseChance; // Chance that a monster house will be itemless (always 0)
+    u8 unk1A; // Unreferenced (always 0)
+    u8 unk1B; // Unreferenced (always 0)
 } FloorProperties;
 
 enum {

--- a/include/structs/str_dungeon.h
+++ b/include/structs/str_dungeon.h
@@ -25,7 +25,7 @@
 typedef struct Weather // 0xE264
 {
     /* 0x0 */ u8 weather; // Uses the weather constants in weather.h.
-    /* 0x1 */ u8 unkE265; // Uses the weather constants in weather.h
+    /* 0x1 */ u8 unkE265; // Uses the weather constants in weather.h.
     /* 0x2 */ u8 weatherDamageCounter; // Timer for applying sandstorm/hail damage periodically.
     /* 0x3 */ u8 unkE267[8];
     /* 0xB */ u8 naturalWeather[8]; // The weather at the start of the floor. If the weather changes, then expires, revert back to the starting weather.
@@ -123,7 +123,7 @@ typedef struct FloorProperties
     s8 roomDensity;
     u8 tileset;
     u8 bgMusic;
-    u8 weather; // See include/constants/weather.h
+    u8 weather; // Uses the weather constants in weather.h.
     u8 floorConnectivity;
     u8 enemyDensity;
     u8 kecleonShopChance; // Percentage chance 0-100%

--- a/include/structs/str_dungeon.h
+++ b/include/structs/str_dungeon.h
@@ -120,12 +120,12 @@ typedef struct UnkDungeonGlobal_unk181E8_sub
 typedef struct FloorProperties
 {
     u8 layout;
-    s8 roomDensity;
+    s8 roomDensity; // If positive, allow variance. If negative, use exact value of abs(roomDensity).
     u8 tileset;
     u8 bgMusic;
     u8 weather; // Uses the weather constants in weather.h.
     u8 floorConnectivity;
-    u8 enemyDensity;
+    u8 enemyDensity; // Game treats this as signed. See SpawnEnemies in src/dungeon_generation.asm for details.
     u8 kecleonShopChance; // Percentage chance 0-100%
     u8 monsterHouseChance; // Percentage chance 0-100%
     u8 mazeRoomChance; // Percentage chance 0-100%

--- a/include/structs/str_dungeon.h
+++ b/include/structs/str_dungeon.h
@@ -140,7 +140,7 @@ typedef struct FloorProperties
     u8 fixedRoomNumber;
     u8 numExtraHallways;
     u8 buriedItemDensity; // Density of buried items (in walls)
-    u8 unk15; // Unreferenced
+    u8 standaloneLakeDensity; // Density of a mass of secondary tiles replacing a wall (i.e. a lake)
     u8 visibilityRange;
     u8 moneyUpperBound; // Generated money stacks cannot exceed this amount (multiplied by 40)
     u8 kecleonShopLayout;

--- a/src/dungeon_config.c
+++ b/src/dungeon_config.c
@@ -597,7 +597,7 @@ const s16 gMoltresConfigLevel = 20;
 const s16 gArticunoConfigLevel = 20;
 const s16 gGroudonConfigLevel = 10;
 
-// Dimensions are [floorProperty unk18][y][x] See sub_8051654
+// Dimensions are [floorProperty kecleonShopLayout][y][x] See sub_8051654
 const s16 sKecleonShopItemSpawnChances[16][3][3] = {
     [0] = {
         {57, 57, 57},

--- a/src/dungeon_generation.c
+++ b/src/dungeon_generation.c
@@ -6097,7 +6097,7 @@ static void sub_8051654(FloorProperties *floorProps)
             if ((tile->terrainFlags & TERRAIN_TYPE_NATURAL_JUNCTION))
                 continue;
 
-            if (sKecleonShopItemSpawnChances[floorProps->unk18][yIndex][xIndex] > DungeonRandInt(100)) {
+            if (sKecleonShopItemSpawnChances[floorProps->kecleonShopLayout][yIndex][xIndex] > DungeonRandInt(100)) {
                 tile->spawnOrVisibilityFlags.spawn |= SPAWN_FLAG_ITEM;
             }
         }

--- a/src/dungeon_generation.c
+++ b/src/dungeon_generation.c
@@ -4423,6 +4423,9 @@ static void SpawnEnemies(FloorProperties *floorProps, bool8 isEmptyMonsterHouse)
     s32 numEnemies, numMonsterHouseEnemies;
     s32 enemyDensity = floorProps->enemyDensity;
 
+    // BUG: Game assumes floorProps->enemyDensity is a signed byte, but in reality it's unsigned.
+    // Attempting to use a negative density will instead produce a very large positive density up to 255. 
+    // This only matters for unused dungeons, as Deoxys has its own logic despite Meteor Cave having an effective enemy density of 255.
 	if (enemyDensity > 0) {
 		// Positive means value with variance
 		numEnemies = DungeonRandRange(enemyDensity / 2, enemyDensity);

--- a/src/dungeon_generation.c
+++ b/src/dungeon_generation.c
@@ -4600,7 +4600,7 @@ static const s32 sNumToGenTable[8] = {1, 1, 1, 2, 2, 2, 3, 3};
  * when a lake is generated.
  *
  * Lakes are a large collection of secondary terrain generated around a central point.
- * Standalone lakes are generated based on secondary_terrain_density
+ * Standalone lakes are generated based on floorProps->standaloneLakeDensity
  *
  * The formations will never cut into room tiles, but can pass through to the other side.
  */
@@ -4779,8 +4779,8 @@ static void GenerateSecondaryTerrainFormations(u32 flag, FloorProperties *floorP
 		}
     }
 
-	// Generate standalone lakes secondary_terrain_density # of times
-	for (densityN = 0; densityN < floorProps->unk15; densityN++) {
+	// Generate standalone lakes floorProps->standaloneLakeDensity # of times
+	for (densityN = 0; densityN < floorProps->standaloneLakeDensity; densityN++) {
         s32 x, y;
         bool8 table[10][10];
 		// Try to pick a random tile in the interior to seed the "lake"

--- a/src/dungeon_items.c
+++ b/src/dungeon_items.c
@@ -83,7 +83,7 @@ void CreateItemWithStickyChance(Item *item, u8 itemID, u32 forceSticky)
     }
 
     if (GetItemCategory(itemID) == CATEGORY_POKE) {
-        sub_8046CE4(item, gDungeon->floorProperties.unk17 * 40);
+        sub_8046CE4(item, gDungeon->floorProperties.moneyUpperBound * 40);
     }
 }
 

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -88,7 +88,7 @@ void sub_803F27C(bool8 a0)
 
     gUnknown_202EDFC = 0xFFFF;
     if (!a0) {
-        strPtr->visibilityRange = gDungeon->floorProperties.unk16 & 3;
+        strPtr->visibilityRange = gDungeon->floorProperties.visibilityRange & 3;
         if (strPtr->visibilityRange == 0) {
             strPtr->unk1820C = 1;
         }

--- a/src/run_dungeon.c
+++ b/src/run_dungeon.c
@@ -309,9 +309,9 @@ void RunDungeon_Async(DungeonSetupStruct *setupPtr)
             gDungeon->unk644.unk40 = 99;
             gDungeon->unk644.unk42 = 99;
             gDungeon->weather.weather = 0;
-            gDungeon->tileset = gDungeon->floorProperties.unk2;
-            gDungeon->unk3A10 = gDungeon->floorProperties.unk3;
-            gDungeon->fixedRoomNumber = gDungeon->floorProperties.unk12;
+            gDungeon->tileset = gDungeon->floorProperties.tileset;
+            gDungeon->unk3A10 = gDungeon->floorProperties.bgMusic;
+            gDungeon->fixedRoomNumber = gDungeon->floorProperties.fixedRoomNumber;
             sub_807E5E4(0);
             sub_80842F0();
         }

--- a/src/unk_dungeon_load_maybe.c
+++ b/src/unk_dungeon_load_maybe.c
@@ -42,7 +42,7 @@ void sub_80ADD9C(OpenedFile **a0, OpenedFile **a1, u32 *a2, void *a3, u16 *a4, c
     }
 
     strPtr = &((struct DungeonMapParam2 *)(mapParamFile->data))->unk0[dungId][dungFloor];
-    r8 = ((struct DungeonMapParam2 *)(mapParamFile->data))->floorProperties[strPtr->unk0].unk2;
+    r8 = ((struct DungeonMapParam2 *)(mapParamFile->data))->floorProperties[strPtr->unk0].tileset;
 
     CloseFile(mapParamFile);
 

--- a/src/weather.c
+++ b/src/weather.c
@@ -51,7 +51,7 @@ u8 GetApparentWeather(Entity *pokemon)
 void sub_807E5AC(void)
 {
     u8 weather;
-    weather = gDungeon->floorProperties.unk4;
+    weather = gDungeon->floorProperties.weather;
     if(weather == WEATHER_COUNT)
         weather = DungeonRandInt(WEATHER_COUNT);
     sub_807E5E4(weather);


### PR DESCRIPTION
Got a lot of help from work done on pull request #43 

I'd like to start converting dungeon main data (more accurately, dungeon floor properties) to JSON, but it seems sensible to update the `FloorProperties` struct first. That way I can justify the keys used for the JSON objects. I'm listing my justifications for the names below, although note that I'm not exactly sold on aspects of `unk17` and `unk18`.

**UPDATE:** Changed `unk15` to `standaloneLakeDensity` after creating this pull request.

**UPDATE 2:** Documented a bug with `enemyDensity`.

## Changes made:
- `unk2` -> `tileset`: I think this one is more like tile properties, as it's a two-digit number that references a whole set of related tile property files. (e.g. Tiny Woods uses tileset 14, which opens `b14fon`, `b14pal`, `b14cel`, `b14cex`, and `b14emap`). However, its equivalent variable in the `Dungeon` struct is named `tileset` and has the same uses, so I decided to stay consistent.
- `unk3` -> `bgMusic`: Never used for anything else.
- `unk4` -> `weather`: Never used for anything else. It's only loaded into a local variable named `weather`.
- `unk11` -> `floorNumber`: Completely unreferenced, but with the exception of D63 and the Makuhita Dojo mazes, it always corresponds to floor number. (The game uses an entirely different system to determine current floor and maximum floor number).
- `unk12` -> `fixedRoomNumber`: Never used for anything else, and its equivalent variable in the `Dungeon` struct is also named `fixedRoomNumber`. In fact, its only use is to get loaded into that variable.
- `unk15` -> `standaloneLakeDensity`: I had initially thought this was unused but it turns out VSCode just didn't see the reference for whatever reason. Found it while playing the game with watchpoints enabled. Went with `standaloneLakeDensity` instead of `secondaryTerrainDensity` because it doesn't affect any other instance of secondary terrain and it otherwise matches existing nomenclature.
- `unk16` -> `visibilityRange`: Never used for anything else, and its equivalent variable in the `UnkDungeonGlobal_unk181E8_sub` substruct is also named `visibilityRange`. Interestingly enough, only the last 2 bits get loaded into that variable, implying this may originally have had other purposes. However, no floor has a value greater than 2 anyway.
- `unk17` -> `moneyUpperBound`: Not entirely sold on this name, but I felt like `maxMoney` would be a misnomer. Dungeon money stacks are generated via picking a random value in a lookup table, and this variable (multiplied by 40) sets the upper bound on what can be returned from that table. It does not itself determine the maximum size money stack. For example, Lost Woods has `moneyUpperBound` = 1 on all its floors, meaning the upper bound is 40, meaning the max value that can be returned from that table is 38. It's possible there's a better name for this. The lookup table can be seen here: https://github.com/pret/pmd-red/blob/master/src/dungeon_data.c#L107
- `unk18` -> `kecleonShopLayout`: Pretty sure I got this right but would appreciate confirmation. It's used as an index to the `sKecleonShopItemSpawnChances` table, but the entries in that table are all identical so it doesn't really seem to do anything. Still, it seems like it's determining the layout of the item spawn chances in a Kecleon Shop, so I went with that name. It's possible this name is confusing and there's a better one but I can't think of anything that isn't overly verbose. The lookup table can be seen here: https://github.com/pret/pmd-red/blob/master/src/dungeon_config.c#L601

## Unreferenced and unused elements

- `unkE`: It's almost certainly a boolean, given it's only ever 1 or 0. It's set in the following dungeons:
  - Lapis Cave B1F-B4F
  - Magma Cavern Pit B1F-B3F
  - Stormy Sea odd number floors
  - Silver Trench odd number floors
  - Meteor Cave B2F-B4F, B6F-B7F, B10F-B11F, B14F-B20F
  - Desert Region B1F-B20F
  - Murky Cave B1F-B19F
  - Marvelous Sea odd number floors
  - Fantasy Strait odd number floors
  - Snow Path B1F-B4F
  - Howling Forest 1F-15F
  - Unown Relic B1F-B11F
It's also set in some unused dungeons. I can't think of what these would have in common, so for now, I'm leaving this as `unkE`. Possible this was re-appropriated to a different part of memory, like `floorNumber`.
- `unk1A`: Always set to 0.
- `unk1B`: Added this just to round out the struct more neatly, but it's always set to 0.

## Documented bug
- `enemyDensity`: Like `roomDensity`, the game treats this as a signed integer, but it's actually unsigned. Trying to use an `enemyDensity` of -1 *should* limit the floor to exactly one enemy spawned, but really it spawns a very large number (as `floorProps->enemyDensity` is loaded into a 32bit local variable). This affects Meteor Cave and some unused dungeons, but since Deoxys has its own logic preventing it from appearing more than once on a floor, only the unused dungeons are in practice affected.