### PR TITLE
Fix softlock on modern when selecting "Team" from menu

### DIFF
--- a/src/text_2.c
+++ b/src/text_2.c
@@ -1175,6 +1175,14 @@ void sub_80089AC(const WindowTemplate *r4, DungeonPos *r5_Str)
         if (r8 > 160)
             r8 = 160;
 
+        // BUG: The background array is 161 entries long, but this function will potentially write
+        // up to index 160 + 12 = 172, overflowing the array.
+#ifdef BUGFIX
+        if (r5 > 160 - 12) {
+            r5 = 160 - 12;
+        }
+#endif
+
         for (i = 0; i < 4; i++) {
             s32 id = r5 * 2;
             if (r6[id] == 240 && r6[id + 1] == 240) {


### PR DESCRIPTION
With modern compiler, the `sFriendList` variable is placed directly after `gUnknown_3000E94` in memory.

`sub_80089AC()`, which appears to draw the background for windows, does incorrect bounds checking, which can cause it to overflow the `gUnknown_3000E94` array. This is problematic for the end of dungeon window, which scrolls up from the bottom of the screen, guaranteeing an overflow. After the overflow, `sFriendList` is overwritten and upon trying to open the "Team" menu, the game softlocks.

Softlock repro steps:
1. Start game
2. Enter a dungeon
3. Select give up from menu
4. After waking up, open menu and select "Team", game softlocks