### PR TITLE
Add UBFIX Define and Standardize #ifdef vs #ifndef

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -60,8 +60,14 @@ static inline bool8 AreStringsDifferent(const u8 *str1, const u8 *str2)
     return strcmp(str1, str2) != 0;
 }
 
+#ifdef BUGFIX
+#ifndef UBFIX
+#define UBFIX
+#endif
+#endif
+
 #ifdef MODERN
-#define BUGFIX
+#define UBFIX
 #define NONMATCHING
 
 #include "mini_printf.h"

--- a/src/dungeon_map.c
+++ b/src/dungeon_map.c
@@ -572,7 +572,7 @@ void TryResetDungeonMapTilesScheduledForCopy(void)
     s32 x, y;
     Dungeon *dungeon = gDungeon;
     if (dungeon->dungeonMap.resetTilesScheduledForCopy) {
-        #ifdef BUGFIX
+        #ifdef UBFIX
         for (y = 0; y < DUNGEON_MAP_MAX_Y; y++) {
             for (x = 0; x < DUNGEON_MAP_MAX_X; x++) {
                 dungeon->dungeonMap.tileScheduledForCopy[y][x] = FALSE;
@@ -584,7 +584,7 @@ void TryResetDungeonMapTilesScheduledForCopy(void)
                 dungeon->dungeonMap.tileScheduledForCopy[y][x] = FALSE;
             }
         }
-        #endif // BUGFIX
+        #endif // UBFIX
         dungeon->dungeonMap.resetTilesScheduledForCopy = FALSE;
     }
 }

--- a/src/ground_script.c
+++ b/src/ground_script.c
@@ -2480,17 +2480,17 @@ static s32 ExecuteScriptCommand(Action *action)
                 // making the target position nonsense. But even if they were correct,
                 // the way the cap is calculated would make the random offset biased off-center.
                 // This doesn't affect the released version because these script commands are never used.
-#ifndef BUGFIX
+#ifdef BUGFIX
+                action->callbacks->getHitboxCenter(action->parentObject, &scriptData->pos1);
+                scriptData->pos2.x = scriptData->pos1.x + ((OtherRandInt(curCmd.arg1 * 2 + 1) - curCmd.arg1) << 8);
+                scriptData->pos2.y = scriptData->pos1.y + ((OtherRandInt(curCmd.arg2 * 2 + 1) - curCmd.arg2) << 8);
+#else
                 s32 cap1 = curCmd.arg1 * 2 - 1;
                 s32 cap2 = curCmd.arg2 * 2 - 1;
 
                 action->callbacks->getHitboxCenter(action->parentObject, &scriptData->pos1);
                 scriptData->pos2.x = scriptData->pos1.x + ((OtherRandInt(cap1) - curCmd.argShort) << 8);
                 scriptData->pos2.y = scriptData->pos1.y + ((OtherRandInt(cap2) - curCmd.arg1) << 8);
-#else
-                action->callbacks->getHitboxCenter(action->parentObject, &scriptData->pos1);
-                scriptData->pos2.x = scriptData->pos1.x + ((OtherRandInt(curCmd.arg1 * 2 + 1) - curCmd.arg1) << 8);
-                scriptData->pos2.y = scriptData->pos1.y + ((OtherRandInt(curCmd.arg2 * 2 + 1) - curCmd.arg2) << 8);
 #endif
                 if (curCmd.op == CMD_BYTE_7F || curCmd.op == CMD_BYTE_85) {
                     scriptData->unk2A = HYPOT;

--- a/src/text_2.c
+++ b/src/text_2.c
@@ -1177,7 +1177,7 @@ void sub_80089AC(const WindowTemplate *r4, DungeonPos *r5_Str)
 
         // BUG: The background array is 161 entries long, but this function will potentially write
         // up to index 160 + 12 = 172, overflowing the array.
-#ifdef BUGFIX
+#ifdef UBFIX
         if (r5 > 160 - 12) {
             r5 = 160 - 12;
         }


### PR DESCRIPTION
Currently, all bugs are covered under a single `#BUGFIX` define regardless of whether they are logical bugs (i.e. valid code that does not have the intended effect) or undefined behavior (i.e. code that may behave properly in agbcc but is not guaranteed to in other compilers, notably modern gcc). It would be beneficial to have a `#UBFIX` define to separate the latter out from the former; currently, if building with modern gcc, `#BUGFIX` is automatically defined. This means that all bugs are fixed, including logic errors present in the original game; this may be unexpected for users. With the changes in this PR, it should now be possible to have identical behavior to the original game even on modern gcc.

Note that this is also the system the mainline games (pokeemerald, pokefirered, etc.) use.

There was also a case of a `#BUGFIX` check using `#ifndef` instead of `#ifdef`; I standardized that while I was at it.