### PR TITLE
Document windowing functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ else
   CC1 := $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
   LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"
   LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
-  override CC1FLAGS += -mthumb -mthumb-interwork -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -Wimplicit -Wparentheses -Wunused -Werror -O2
+  override CC1FLAGS += -mthumb -mthumb-interwork -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -Wimplicit -Wparentheses -Wunused -Werror -O2 -g -Wno-unused-variable -Wno-incompatible-pointer-types
   INCLUDE_DIRS := include
   INCLUDE_CPP_ARGS := $(INCLUDE_DIRS:%=-iquote %)
   INCLUDE_PATHS := $(INCLUDE_DIRS:%=-I %)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ else
   CC1 := $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
   LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"
   LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
-  override CC1FLAGS += -mthumb -mthumb-interwork -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -Wimplicit -Wparentheses -Wunused -Werror -O2 -g -Wno-unused-variable -Wno-incompatible-pointer-types
+  override CC1FLAGS += -mthumb -mthumb-interwork -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -Wimplicit -Wparentheses -Wunused -Werror -O2 -g
   INCLUDE_DIRS := include
   INCLUDE_CPP_ARGS := $(INCLUDE_DIRS:%=-iquote %)
   INCLUDE_PATHS := $(INCLUDE_DIRS:%=-I %)

--- a/include/code_800558C.h
+++ b/include/code_800558C.h
@@ -7,8 +7,17 @@ extern s16 gUnknown_2026E4E;
 
 extern s16 *gWindowBgCopy;
 
-void sub_80057E8(void);
-void CopyWindowBgBuffer(s32 *, u8 kind);
+typedef enum CopyWindowBgBufferType {
+    COPY_WINDOW_BG_BUFFER_DEFAULT,
+    COPY_WINDOW_BG_BUFFER_DIM2,
+    COPY_WINDOW_BG_BUFFER_DIM1,
+    COPY_WINDOW_BG_BUFFER_UNK3,
+    COPY_WINDOW_BG_BUFFER_UNK4,
+    COPY_WINDOW_BG_BUFFER_UNK5,
+} CopyWindowBgBufferType;
+
+void WindowBgBufferInit(void);
+void CopyWindowBgBuffer(s32 *a0, u8 kind);
 void ToggleWindowBgBuffer(void);
 
 #endif // GUARD_CODE_800558C_H

--- a/include/code_800558C.h
+++ b/include/code_800558C.h
@@ -8,7 +8,7 @@ extern s16 gUnknown_2026E4E;
 extern s16 *gWindowBgCopy;
 
 typedef enum CopyWindowBgBufferType {
-    COPY_WINDOW_BG_BUFFER_DEFAULT,
+    COPY_WINDOW_BG_BUFFER_WIN0,
     COPY_WINDOW_BG_BUFFER_DIM2,     // Dim while in light darkness corridor
     COPY_WINDOW_BG_BUFFER_DIM1,     // Same but for heavy darkness
     COPY_WINDOW_BG_BUFFER_ROOM_DIM, // While in a room, dim outside

--- a/include/code_800558C.h
+++ b/include/code_800558C.h
@@ -2,22 +2,22 @@
 #define GUARD_CODE_800558C_H
 
 extern bool8 gDrawWindow;
-extern s16 *gWin0HPtr;
+extern s16 *gWinBufferPtr;
 extern s16 gUnknown_2026E4E;
 
 extern s16 *gWindowBgCopy;
 
 typedef enum CopyWindowBgBufferType {
     COPY_WINDOW_BG_BUFFER_DEFAULT,
-    COPY_WINDOW_BG_BUFFER_DIM2,
-    COPY_WINDOW_BG_BUFFER_DIM1,
-    COPY_WINDOW_BG_BUFFER_UNK3,
+    COPY_WINDOW_BG_BUFFER_DIM2,     // Dim while in light darkness corridor
+    COPY_WINDOW_BG_BUFFER_DIM1,     // Same but for heavy darkness
+    COPY_WINDOW_BG_BUFFER_ROOM_DIM, // While in a room, dim outside
     COPY_WINDOW_BG_BUFFER_UNK4,
     COPY_WINDOW_BG_BUFFER_UNK5,
 } CopyWindowBgBufferType;
 
 void WindowBgBufferInit(void);
-void CopyWindowBgBuffer(s32 *a0, u8 kind);
+void CopyWindowBgBuffer(s32 *pos, u8 kind);
 void ToggleWindowBgBuffer(void);
 
 #endif // GUARD_CODE_800558C_H

--- a/include/code_800558C.h
+++ b/include/code_800558C.h
@@ -9,6 +9,6 @@ extern s16 *gWindowBgCopy;
 
 void sub_80057E8(void);
 void sub_8005838(s32 *, u8 kind);
-void sub_80060EC(void);
+void ToggleWindowBgBuffer(void);
 
 #endif // GUARD_CODE_800558C_H

--- a/include/code_800558C.h
+++ b/include/code_800558C.h
@@ -8,7 +8,7 @@ extern s16 gUnknown_2026E4E;
 extern s16 *gWindowBgCopy;
 
 void sub_80057E8(void);
-void sub_8005838(s32 *, u8 kind);
+void CopyWindowBgBuffer(s32 *, u8 kind);
 void ToggleWindowBgBuffer(void);
 
 #endif // GUARD_CODE_800558C_H

--- a/include/code_800558C.h
+++ b/include/code_800558C.h
@@ -1,11 +1,11 @@
 #ifndef GUARD_CODE_800558C_H
 #define GUARD_CODE_800558C_H
 
-extern bool8 gUnknown_2026E38;
-extern s16 *gUnknown_2026E3C;
+extern bool8 gDrawWindow;
+extern s16 *gWin0HPtr;
 extern s16 gUnknown_2026E4E;
 
-extern s16 *gUnknown_203B078;
+extern s16 *gWindowBgCopy;
 
 void sub_80057E8(void);
 void sub_8005838(s32 *, u8 kind);

--- a/include/text_1.h
+++ b/include/text_1.h
@@ -43,7 +43,7 @@ extern void (*ScrollUpWindowFunc)(s32 windowId);
 extern void (*gIwramTextFunc3)(s32 a0);
 extern void (*gIwramTextFunc4)(s32 a0);
 
-extern s16 gUnknown_3000E94[161];
+extern s16 gWindowBg[161];
 
 extern const u32 gUnknown_80B853C[16];
 extern const unkShiftData gCharMasksOffsets[8];

--- a/include/text_2.h
+++ b/include/text_2.h
@@ -16,7 +16,7 @@ void sub_8007B7C(u32 a0, s32 x, s32 y, s32 a3, u32 color);
 // srcGFX: Each u32 is 8 packed pixels, 4 bits per pixel.
 void WriteGFXToBG0Window(u32 winID, u32 x, u32 y, u32 w, u32 h, u32 *srcGFX, u32 palNum);
 void sub_80087EC(s32 a0, s32 a1, s32 a2, s32 a3, s32 a4);
-void sub_80089AC(const WindowTemplate *r4, DungeonPos *r5_Str);
+void DrawWindowBg(const WindowTemplate *window, DungeonPos *pos);
 u32 DrawCharOnWindow(s32 x, s32 y, u32 chr, u32 color, u32 windowId);
 bool8 xxx_call_update_bg_vram(void);
 u32 DrawCharOnWindowInternal(Window *windows, s32 x, s32 y, u32 chr, u32 color, u32 windowId);

--- a/include/window_buffer.h
+++ b/include/window_buffer.h
@@ -1,5 +1,5 @@
-#ifndef GUARD_CODE_800558C_H
-#define GUARD_CODE_800558C_H
+#ifndef GUARD_WINDOW_BUFFER_H
+#define GUARD_WINDOW_BUFFER_H
 
 extern bool8 gDrawWindow;
 extern s16 *gWinBufferPtr;
@@ -20,4 +20,4 @@ void WindowBgBufferInit(void);
 void CopyWindowBgBuffer(s32 *pos, u8 kind);
 void ToggleWindowBgBuffer(void);
 
-#endif // GUARD_CODE_800558C_H
+#endif // GUARD_WINDOW_BUFFER_H

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -62,7 +62,7 @@ SECTIONS {
         src/input.o(.text);
         src/code_8004AA0.o(.text);
         src/sprite.o(.text);
-        src/code_800558C.o(.text);
+        src/window_buffer.o(.text);
         src/random.o(.text);
         src/text_1.o(.text);
         src/text_2.o(.text);
@@ -440,7 +440,7 @@ SECTIONS {
         src/input.o(.rodata);
         src/code_8004AA0.o(.rodata);
         src/sprite.o(.rodata);
-        src/code_800558C.o(.rodata);
+        src/window_buffer.o(.rodata);
         src/random.o(.rodata);
         src/text_1.o(.rodata);
         src/text_2.o(.rodata);

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -7,7 +7,7 @@
 #define UNROLL16(x) do { x; x; x; x; x; x; x; x; x; x; x; x; x; x; x; x; } while (0)
 
 EWRAM_DATA bool8 gDrawWindow = FALSE;
-EWRAM_DATA s16 *gWin0HPtr = NULL;
+EWRAM_DATA s16 *gWinBufferPtr = NULL;
 EWRAM_DATA static s32 sUnknown_2026E40 = 0; // Read from but never written to
 EWRAM_DATA static s32 sUnknown_2026E44 = 0; // Read from but never written to
 EWRAM_DATA static s32 sUnknown_2026E48 = 0; // Read from but never written to
@@ -22,10 +22,12 @@ EWRAM_DATA static s16 sBuffer1[324] = {0};
 
 EWRAM_INIT s16 *gWindowBgCopy = NULL;
 
-static const s16 gUnknown_80B8008[17] = {16, 12, 9, 7, 6, 5, 4, 3, 2, 2, 1, 1, 1, 0, 0, 0, 0};
+// Rounded corners in low visibility rooms
+static const s16 sRoomCornerDim[17] = {16, 12, 9, 7, 6, 5, 4, 3, 2, 2, 1, 1, 1, 0, 0, 0, 0};
 
 #define Y_MAX 160
-// Dim edges of screen in corridors with 1 visibility
+#define X_MAX 240
+// In corridor with heavy darkness, dim everything except a small circle
 static const s16 sCorridorDim1[Y_MAX] = {
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
@@ -51,7 +53,7 @@ static const s16 sCorridorDim1[Y_MAX] = {
     0x100, 0x100, 0x100
 };
 
-// Dim edges of screen in corridors with 2 visibility
+// In corridor with light darkness, dim everything except a larger circle
 static const s16 sCorridorDim2[Y_MAX] = {
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
@@ -96,14 +98,14 @@ void WindowBgBufferInit(void)
     sBufferIdx = FALSE;
     sBoolUnk = TRUE;
     sBufferPtr = NULL;
-    gWin0HPtr = NULL;
+    gWinBufferPtr = NULL;
     gDrawWindow = FALSE;
     gUnknown_2026E4E = 0x60C;
     gWindowBgCopy = NULL;
 }
 
 // arm9.bin::02005758
-void CopyWindowBgBuffer(s32 *a0, u8 kind)
+void CopyWindowBgBuffer(s32 *pos, u8 kind)
 {
     const s16 *src1, *src2;
     s16 *dst;
@@ -123,68 +125,79 @@ void CopyWindowBgBuffer(s32 *a0, u8 kind)
     switch (kind) {
         case COPY_WINDOW_BG_BUFFER_DEFAULT:
             for (i = 0; i < 10; i++) {
-                UNROLL16(*dst++ = *src1++; *dst++ = 0;);
+                UNROLL16(
+                    *dst++ = *src1++;   // WIN0H
+                    *dst++ = 0;         // WIN1H (disabled)
+                );
             }
             break;
         case COPY_WINDOW_BG_BUFFER_DIM2:
             src2 = sCorridorDim2;
             for (i = 0; i < 10; i++) {
-                UNROLL16(*dst++ = *src1++; *dst++ = *src2++;);
+                UNROLL16(
+                    *dst++ = *src1++;   // WIN0H
+                    *dst++ = *src2++;   // WIN1H (dim)
+                );
             }
             break;
         case COPY_WINDOW_BG_BUFFER_DIM1:
             src2 = sCorridorDim1;
             for (i = 0; i < 10; i++) {
-                UNROLL16(*dst++ = *src1++; *dst++ = *src2++;);
+                UNROLL16(
+                    *dst++ = *src1++;   // WIN0H
+                    *dst++ = *src2++;   // WIN1H (dim)
+                );
             }
             break;
-        case COPY_WINDOW_BG_BUFFER_UNK3:
-            if ((a0[0] < 0 && a0[2] < 0)
-                || (a0[1] < 0 && a0[3] < 0)
-                || (a0[0] >= 240 && a0[2] >= 240)
-                || (a0[1] >= 160 && a0[3] >= 160)) {
+        case COPY_WINDOW_BG_BUFFER_ROOM_DIM:
+            if ((pos[0] < 0 && pos[2] < 0)
+                || (pos[1] < 0 && pos[3] < 0)
+                || (pos[0] >= X_MAX && pos[2] >= X_MAX)
+                || (pos[1] >= Y_MAX && pos[3] >= Y_MAX)) {
+                // If the camera is outside the room, dim the entire screen
                 for (i = 0; i < 10; i++) {
-                    UNROLL16(*dst++ = *src1++; *dst++ = 240;);
+                    UNROLL16(*dst++ = *src1++; *dst++ = 0xF0;);
                 }
             }
             else {
-                s32 iVar5;
-                s32 r4;
-                for (i = 0; i < 160; i++) {
-                    if (a0[1] > i) {
+                s32 left;
+                s32 right;
+                for (i = 0; i < Y_MAX; i++) {
+                    if (pos[1] > i) {
                         *dst++ = *src1++;
                         *dst++ = 256;
                     }
-                    else if (a0[3] <= i) {
+                    else if (pos[3] <= i) {
                         *dst++ = *src1++;
                         *dst++ = 256;
                     }
                     else {
-                        if (i - a0[1] < 16) {
-                            r4 = a0[0] + gUnknown_80B8008[i - a0[1]];
-                            iVar5 = a0[2] - gUnknown_80B8008[i - a0[1]];
+                        if (i - pos[1] < 16) {
+                            right = pos[0] + sRoomCornerDim[i - pos[1]];
+                            left = pos[2] - sRoomCornerDim[i - pos[1]];
                         }
-                        else if (a0[3] - i < 16) {
-                            r4 = a0[0] + gUnknown_80B8008[a0[3] - i];
-                            iVar5 = a0[2] - gUnknown_80B8008[a0[3] - i];
+                        else if (pos[3] - i < 16) {
+                            right = pos[0] + sRoomCornerDim[pos[3] - i];
+                            left = pos[2] - sRoomCornerDim[pos[3] - i];
                         }
                         else {
-                            r4 = a0[0];
-                            iVar5 = a0[2];
+                            right = pos[0];
+                            left = pos[2];
                         }
 
-                        if (r4 < 0)
-                            r4 = 0;
-                        if (r4 > 240 - 1)
-                            r4 = 240 - 1;
+                        if (right < 0)
+                            right = 0;
+                        if (right > X_MAX - 1)
+                            right = X_MAX - 1;
 
-                        if (iVar5 < 1)
-                            iVar5 = 1;
-                        if (iVar5 > 240)
-                            iVar5 = 240;
+                        if (left < 1)
+                            left = 1;
+                        if (left > X_MAX)
+                            left = X_MAX;
 
                         *dst++ = *src1++;
-                        *dst++ = (iVar5 << 8) | r4;
+                        // Note this is backwards so the dim window is drawn on the outside
+                        *dst++ = (left << 8) | right;
                     }
                 }
             }
@@ -281,7 +294,7 @@ void CopyWindowBgBuffer(s32 *a0, u8 kind)
 #if (GAME_VERSION == VERSION_RED)
 UNUSED static void sub_80060A8(void)
 {
-    gWin0HPtr = sBufferPtr;
+    gWinBufferPtr = sBufferPtr;
     sBufferIdx = !sBufferIdx;
     sBoolUnk = !sBoolUnk;
     gDrawWindow = FALSE;
@@ -291,7 +304,7 @@ UNUSED static void sub_80060A8(void)
 // arm9.bin::020056C0
 void ToggleWindowBgBuffer(void)
 {
-    gWin0HPtr = sBufferPtr;
+    gWinBufferPtr = sBufferPtr;
     sBufferIdx = !sBufferIdx;
     sBoolUnk = !sBoolUnk;
     SetBldAlphaReg((gUnknown_2026E4E & 0x1F00) >> 8, gUnknown_2026E4E & 0x1F);

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -4,27 +4,28 @@
 #include "code_800558C.h"
 #include "math.h"
 
-EWRAM_DATA bool8 gUnknown_2026E38 = FALSE;
-EWRAM_DATA s16 *gUnknown_2026E3C = NULL;
+EWRAM_DATA bool8 gDrawWindow = FALSE;
+EWRAM_DATA s16 *gWin0HPtr = NULL;
 EWRAM_DATA static s32 sUnknown_2026E40 = 0; // Read from but never written to
 EWRAM_DATA static s32 sUnknown_2026E44 = 0; // Read from but never written to
 EWRAM_DATA static s32 sUnknown_2026E48 = 0; // Read from but never written to
-EWRAM_DATA static bool8 sUnknown_2026E4C = FALSE;
+EWRAM_DATA static bool8 sInitialized = FALSE;
 EWRAM_DATA s16 gUnknown_2026E4E = 0;
-EWRAM_DATA static bool32 sUnknown_2026E50 = FALSE;
-EWRAM_DATA static bool32 sUnknown_2026E54 = FALSE;
-EWRAM_DATA static s16 *sUnknown_2026E58 = NULL;
+EWRAM_DATA static bool32 sBoolUnk = FALSE;      // Toggled but is never read
+EWRAM_DATA static bool32 sBufferIdx = FALSE;    // Write to sBuffer0 or sBuffer1
+EWRAM_DATA static s16 *sBufferPtr = NULL;
 UNUSED EWRAM_DATA static u32 sUnused0 = 0;
-EWRAM_DATA static s16 sUnknown_2026E60[324] = {0}; // These might be [2][162]
-EWRAM_DATA static s16 sUnknown_20270E8[324] = {0};
+EWRAM_DATA static s16 sBuffer0[324] = {0}; // These might be [2][162]
+EWRAM_DATA static s16 sBuffer1[324] = {0};
 
-EWRAM_INIT s16 *gUnknown_203B078 = NULL;
+EWRAM_INIT s16 *gWindowBgCopy = NULL;
 
 static const s16 gUnknown_80B8008[17] = {16, 12, 9, 7, 6, 5, 4, 3, 2, 2, 1, 1, 1, 0, 0, 0, 0};
 
-#define UNK_TABLES_ARR_COUNT 160
+#define Y_MAX 160
 
-static const s16 gUnknown_80B802A[UNK_TABLES_ARR_COUNT] = {
+// Dim edges of screen in corridors with 1 visibility
+static const s16 sCorridorDim1[Y_MAX] = {
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
@@ -49,7 +50,8 @@ static const s16 gUnknown_80B802A[UNK_TABLES_ARR_COUNT] = {
     0x100, 0x100, 0x100
 };
 
-static const s16 gUnknown_80B816A[UNK_TABLES_ARR_COUNT] = {
+// Dim edges of screen in corridors with 2 visibility
+static const s16 sCorridorDim2[Y_MAX] = {
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
@@ -75,28 +77,28 @@ static const s16 gUnknown_80B816A[UNK_TABLES_ARR_COUNT] = {
     0x100
 };
 
-// Almost all 0x100
-static const s16 gUnknown_80B82AA[UNK_TABLES_ARR_COUNT] = {
+// Almost all 0x100 (unused?)
+static const s16 gUnknown_80B82AA[Y_MAX] = {
     [0 ... 2] = 0x100,
     [3] = 0x9392,
-    [4 ... UNK_TABLES_ARR_COUNT - 1] = 0x100
+    [4 ... Y_MAX - 1] = 0x100
 };
-// All zeroes
-static const s16 gUnknown_80B83EA[UNK_TABLES_ARR_COUNT] = {
-    [0 ... UNK_TABLES_ARR_COUNT - 1] = 0
+// All zeroes (fallback?)
+static const s16 sDefaultBgH[Y_MAX] = {
+    [0 ... Y_MAX - 1] = 0
 };
 
 // arm9.bin::02006154
 void sub_80057E8(void)
 {
-    sUnknown_2026E4C = TRUE;
-    sUnknown_2026E54 = FALSE;
-    sUnknown_2026E50 = TRUE;
-    sUnknown_2026E58 = NULL;
-    gUnknown_2026E3C = NULL;
-    gUnknown_2026E38 = FALSE;
+    sInitialized = TRUE;
+    sBufferIdx = FALSE;
+    sBoolUnk = TRUE;
+    sBufferPtr = NULL;
+    gWin0HPtr = NULL;
+    gDrawWindow = FALSE;
     gUnknown_2026E4E = 0x60C;
-    gUnknown_203B078 = NULL;
+    gWindowBgCopy = NULL;
 }
 
 // arm9.bin::02005758
@@ -106,16 +108,16 @@ void sub_8005838(s32 *a0, u8 kind)
     s16 *dst;
     s32 i;
 
-    if (!sUnknown_2026E4C)
+    if (!sInitialized)
         kind = 0;
 
-    dst = !sUnknown_2026E54 ? sUnknown_2026E60 : sUnknown_20270E8;
+    dst = !sBufferIdx ? sBuffer0 : sBuffer1;
 
-    src1 = gUnknown_203B078;
+    src1 = gWindowBgCopy;
     if (src1 == NULL)
-        src1 = gUnknown_80B83EA;
+        src1 = sDefaultBgH;
 
-    sUnknown_2026E58 = dst;
+    sBufferPtr = dst;
 
     switch (kind) {
         case 0:
@@ -155,7 +157,7 @@ void sub_8005838(s32 *a0, u8 kind)
             }
             break;
         case 1:
-            src2 = gUnknown_80B816A;
+            src2 = sCorridorDim2;
             for (i = 0; i < 10; i++) {
                 *dst++ = *src1++;
                 *dst++ = *src2++;
@@ -192,7 +194,7 @@ void sub_8005838(s32 *a0, u8 kind)
             }
             break;
         case 2:
-            src2 = gUnknown_80B802A;
+            src2 = sCorridorDim1;
             for (i = 0; i < 10; i++) {
                 *dst++ = *src1++;
                 *dst++ = *src2++;
@@ -437,10 +439,10 @@ void sub_8005838(s32 *a0, u8 kind)
                         if (j >= 160)
                             continue;
 
-                        if (!sUnknown_2026E54)
-                            sUnknown_2026E60[j * 2 + 1] = uVar7;
+                        if (!sBufferIdx)
+                            sBuffer0[j * 2 + 1] = uVar7;
                         else
-                            sUnknown_20270E8[j * 2 + 1] = uVar7;
+                            sBuffer1[j * 2 + 1] = uVar7;
                     }
 
                     for (; k > r8; k--) {
@@ -449,10 +451,10 @@ void sub_8005838(s32 *a0, u8 kind)
                         if (k >= 160)
                             continue;
 
-                        if (!sUnknown_2026E54)
-                            sUnknown_2026E60[k * 2 + 1] = uVar7;
+                        if (!sBufferIdx)
+                            sBuffer0[k * 2 + 1] = uVar7;
                         else
-                            sUnknown_20270E8[k * 2 + 1] = uVar7;
+                            sBuffer1[k * 2 + 1] = uVar7;
                     }
                 }
             }
@@ -464,19 +466,19 @@ void sub_8005838(s32 *a0, u8 kind)
 #if (GAME_VERSION == VERSION_RED)
 UNUSED static void sub_80060A8(void)
 {
-    gUnknown_2026E3C = sUnknown_2026E58;
-    sUnknown_2026E54 = !sUnknown_2026E54;
-    sUnknown_2026E50 = !sUnknown_2026E50;
-    gUnknown_2026E38 = FALSE;
+    gWin0HPtr = sBufferPtr;
+    sBufferIdx = !sBufferIdx;
+    sBoolUnk = !sBoolUnk;
+    gDrawWindow = FALSE;
 }
 #endif
 
 // arm9.bin::020056C0
 void sub_80060EC(void)
 {
-    gUnknown_2026E3C = sUnknown_2026E58;
-    sUnknown_2026E54 = !sUnknown_2026E54;
-    sUnknown_2026E50 = !sUnknown_2026E50;
+    gWin0HPtr = sBufferPtr;
+    sBufferIdx = !sBufferIdx;
+    sBoolUnk = !sBoolUnk;
     SetBldAlphaReg((gUnknown_2026E4E & 0x1F00) >> 8, gUnknown_2026E4E & 0x1F);
-    gUnknown_2026E38 = TRUE;
+    gDrawWindow = TRUE;
 }

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -4,24 +4,7 @@
 #include "code_800558C.h"
 #include "math.h"
 
-#define UNROLL16(x) do { \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-    x; \
-} while (0)
+#define UNROLL16(x) do { x; x; x; x; x; x; x; x; x; x; x; x; x; x; x; x; } while (0)
 
 EWRAM_DATA bool8 gDrawWindow = FALSE;
 EWRAM_DATA s16 *gWin0HPtr = NULL;

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -112,7 +112,7 @@ void CopyWindowBgBuffer(s32 *pos, u8 kind)
     s32 i;
 
     if (!sInitialized)
-        kind = COPY_WINDOW_BG_BUFFER_DEFAULT;
+        kind = COPY_WINDOW_BG_BUFFER_WIN0;
 
     dst = !sBufferIdx ? sBuffer0 : sBuffer1;
 
@@ -123,7 +123,7 @@ void CopyWindowBgBuffer(s32 *pos, u8 kind)
     sBufferPtr = dst;
 
     switch (kind) {
-        case COPY_WINDOW_BG_BUFFER_DEFAULT:
+        case COPY_WINDOW_BG_BUFFER_WIN0:
             for (i = 0; i < 10; i++) {
                 UNROLL16(
                     *dst++ = *src1++;   // WIN0H

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -102,7 +102,7 @@ void sub_80057E8(void)
 }
 
 // arm9.bin::02005758
-void sub_8005838(s32 *a0, u8 kind)
+void CopyWindowBgBuffer(s32 *a0, u8 kind)
 {
     const s16 *src1, *src2;
     s16 *dst;

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -4,6 +4,25 @@
 #include "code_800558C.h"
 #include "math.h"
 
+#define UNROLL16(x) do { \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+    x; \
+} while (0)
+
 EWRAM_DATA bool8 gDrawWindow = FALSE;
 EWRAM_DATA s16 *gWin0HPtr = NULL;
 EWRAM_DATA static s32 sUnknown_2026E40 = 0; // Read from but never written to
@@ -23,7 +42,6 @@ EWRAM_INIT s16 *gWindowBgCopy = NULL;
 static const s16 gUnknown_80B8008[17] = {16, 12, 9, 7, 6, 5, 4, 3, 2, 2, 1, 1, 1, 0, 0, 0, 0};
 
 #define Y_MAX 160
-
 // Dim edges of screen in corridors with 1 visibility
 static const s16 sCorridorDim1[Y_MAX] = {
     0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
@@ -89,7 +107,7 @@ static const s16 sDefaultBgH[Y_MAX] = {
 };
 
 // arm9.bin::02006154
-void sub_80057E8(void)
+void WindowBgBufferInit(void)
 {
     sInitialized = TRUE;
     sBufferIdx = FALSE;
@@ -109,7 +127,7 @@ void CopyWindowBgBuffer(s32 *a0, u8 kind)
     s32 i;
 
     if (!sInitialized)
-        kind = 0;
+        kind = COPY_WINDOW_BG_BUFFER_DEFAULT;
 
     dst = !sBufferIdx ? sBuffer0 : sBuffer1;
 
@@ -120,154 +138,30 @@ void CopyWindowBgBuffer(s32 *a0, u8 kind)
     sBufferPtr = dst;
 
     switch (kind) {
-        case 0:
+        case COPY_WINDOW_BG_BUFFER_DEFAULT:
             for (i = 0; i < 10; i++) {
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
-                *dst++ = *src1++;
-                *dst++ = 0;
+                UNROLL16(*dst++ = *src1++; *dst++ = 0;);
             }
             break;
-        case 1:
+        case COPY_WINDOW_BG_BUFFER_DIM2:
             src2 = sCorridorDim2;
             for (i = 0; i < 10; i++) {
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
+                UNROLL16(*dst++ = *src1++; *dst++ = *src2++;);
             }
             break;
-        case 2:
+        case COPY_WINDOW_BG_BUFFER_DIM1:
             src2 = sCorridorDim1;
             for (i = 0; i < 10; i++) {
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
+                UNROLL16(*dst++ = *src1++; *dst++ = *src2++;);
             }
             break;
-        case 3:
+        case COPY_WINDOW_BG_BUFFER_UNK3:
             if ((a0[0] < 0 && a0[2] < 0)
                 || (a0[1] < 0 && a0[3] < 0)
                 || (a0[0] >= 240 && a0[2] >= 240)
                 || (a0[1] >= 160 && a0[3] >= 160)) {
                 for (i = 0; i < 10; i++) {
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
-                    *dst++ = *src1++;
-                    *dst++ = 240;
+                    UNROLL16(*dst++ = *src1++; *dst++ = 240;);
                 }
             }
             else {
@@ -312,44 +206,13 @@ void CopyWindowBgBuffer(s32 *a0, u8 kind)
                 }
             }
             break;
-        case 4:
+        case COPY_WINDOW_BG_BUFFER_UNK4:
             src2 = gUnknown_80B82AA;
             for (i = 0; i < 15; i++) {
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
-                *dst++ = *src1++;
-                *dst++ = *src2++;
+                UNROLL16(*dst++ = *src1++; *dst++ = *src2++;);
             }
             break;
-        case 5: {
+        case COPY_WINDOW_BG_BUFFER_UNK5: {
             s32 r8;
             s32 sp14;
             s32 uVar7;
@@ -364,38 +227,7 @@ void CopyWindowBgBuffer(s32 *a0, u8 kind)
             s32 j, k;
 
             for (i = 0; i < 15; i++) {
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
-                *dst++ = *src1++;
-                *dst++ = 256;
+                UNROLL16(*dst++ = *src1++; *dst++ = 256;);
             }
 
             val1 = sUnknown_2026E40;

--- a/src/code_800558C.c
+++ b/src/code_800558C.c
@@ -474,7 +474,7 @@ UNUSED static void sub_80060A8(void)
 #endif
 
 // arm9.bin::020056C0
-void sub_80060EC(void)
+void ToggleWindowBgBuffer(void)
 {
     gWin0HPtr = sBufferPtr;
     sBufferIdx = !sBufferIdx;

--- a/src/code_8040094_1.c
+++ b/src/code_8040094_1.c
@@ -4,7 +4,7 @@
 #include "constants/type.h"
 #include "constants/weather.h"
 #include "structs/str_dungeon.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "code_8040094_1.h"
 #include "dungeon_8041AD0.h"
 #include "dungeon_info.h"

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -81,10 +81,13 @@ void VBlank_CB(void)
     REG_BLDCNT = gBldCnt;
     REG_BLDALPHA = gBldAlpha;
     if (gDrawWindow) {
-        // Very interesting use of DmaCopy16 here.
+        // Write the next 2 values from gWinBufferPtr to WIN0H/WIN1H every HBlank, allows for drawing
+        // non-rectangular windows
         DmaSet(0, &gWinBufferPtr[2], REG_ADDR_WIN0H, ((DMA_ENABLE | DMA_START_HBLANK | DMA_REPEAT | DMA_SRC_INC | DMA_DEST_RELOAD | DMA_16BIT) << 16) | 2);
+        // Manually set the first WIN0H and WIN1H values
         REG_WIN0H = gWinBufferPtr[0];
         REG_WIN1H = gWinBufferPtr[1];
+        // Set WIN0V/WIN1V to max screen dimensions
         REG_WIN0V = DISPLAY_HEIGHT;
         REG_WIN1V = DISPLAY_HEIGHT;
     }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -82,9 +82,9 @@ void VBlank_CB(void)
     REG_BLDALPHA = gBldAlpha;
     if (gDrawWindow) {
         // Very interesting use of DmaCopy16 here.
-        DmaSet(0, &gWin0HPtr[2], REG_ADDR_WIN0H, ((DMA_ENABLE | DMA_START_HBLANK | DMA_REPEAT | DMA_SRC_INC | DMA_DEST_RELOAD | DMA_16BIT) << 16) | 2);
-        REG_WIN0H = gWin0HPtr[0];
-        REG_WIN1H = gWin0HPtr[1];
+        DmaSet(0, &gWinBufferPtr[2], REG_ADDR_WIN0H, ((DMA_ENABLE | DMA_START_HBLANK | DMA_REPEAT | DMA_SRC_INC | DMA_DEST_RELOAD | DMA_16BIT) << 16) | 2);
+        REG_WIN0H = gWinBufferPtr[0];
+        REG_WIN1H = gWinBufferPtr[1];
         REG_WIN0V = DISPLAY_HEIGHT;
         REG_WIN1V = DISPLAY_HEIGHT;
     }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -1,6 +1,6 @@
 #include "global.h"
 #include "bg_control.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "cpu.h"
 
 EWRAM_DATA u32 gUnknown_202D800 = {0};

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -80,11 +80,11 @@ void VBlank_CB(void)
     REG_WINOUT = WINOUT_WIN01_OBJ | WINOUT_WIN01_CLR | WINOUT_WIN01_BG3 | WINOUT_WIN01_BG2 | WINOUT_WIN01_BG0;
     REG_BLDCNT = gBldCnt;
     REG_BLDALPHA = gBldAlpha;
-    if (gUnknown_2026E38) {
+    if (gDrawWindow) {
         // Very interesting use of DmaCopy16 here.
-        DmaSet(0, &gUnknown_2026E3C[2], REG_ADDR_WIN0H, ((DMA_ENABLE | DMA_START_HBLANK | DMA_REPEAT | DMA_SRC_INC | DMA_DEST_RELOAD | DMA_16BIT) << 16) | 2);
-        REG_WIN0H = gUnknown_2026E3C[0];
-        REG_WIN1H = gUnknown_2026E3C[1];
+        DmaSet(0, &gWin0HPtr[2], REG_ADDR_WIN0H, ((DMA_ENABLE | DMA_START_HBLANK | DMA_REPEAT | DMA_SRC_INC | DMA_DEST_RELOAD | DMA_16BIT) << 16) | 2);
+        REG_WIN0H = gWin0HPtr[0];
+        REG_WIN1H = gWin0HPtr[1];
         REG_WIN0V = DISPLAY_HEIGHT;
         REG_WIN1V = DISPLAY_HEIGHT;
     }

--- a/src/debug_field_map.c
+++ b/src/debug_field_map.c
@@ -38,7 +38,7 @@ UNUSED static void DebugMapViewer(void)
     sub_809975C();
     sub_809D0AC();
     ResetDialogueBox();
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     AllocGroundMapAction();
     while (TRUE) {
         bool8 quitMapView;
@@ -48,7 +48,7 @@ UNUSED static void DebugMapViewer(void)
         if (DebugFieldMapWindow_Init()) {
             DebugFieldMapWindow_MoveMenuTo(mapId);
             while (TRUE) {
-                sub_8005838(NULL, 0);
+                CopyWindowBgBuffer(NULL, 0);
                 sub_8012A18(0);
                 switch (DebugFieldMapWindow_GetInput()) {
                     case MENU_INPUT_A_PRESS:
@@ -132,7 +132,7 @@ UNUSED static void DebugMapViewer(void)
             sub_809D25C();
             sub_80A59DC();
             DrawDialogueBoxString_Async();
-            sub_8005838(NULL, 0);
+            CopyWindowBgBuffer(NULL, 0);
             ToggleWindowBgBuffer();
             nullsub_8(gGameOptionsRef->touchScreen);
             sub_8005180();

--- a/src/debug_field_map.c
+++ b/src/debug_field_map.c
@@ -2,7 +2,7 @@
 #include "globaldata.h"
 #include "debug_field_map_window.h"
 #include "music_util.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "code_8099360.h"
 #include "code_800C9CC.h"
 #include "graphics_memory.h"

--- a/src/debug_field_map.c
+++ b/src/debug_field_map.c
@@ -38,7 +38,7 @@ UNUSED static void DebugMapViewer(void)
     sub_809975C();
     sub_809D0AC();
     ResetDialogueBox();
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     AllocGroundMapAction();
     while (TRUE) {
         bool8 quitMapView;
@@ -48,7 +48,7 @@ UNUSED static void DebugMapViewer(void)
         if (DebugFieldMapWindow_Init()) {
             DebugFieldMapWindow_MoveMenuTo(mapId);
             while (TRUE) {
-                CopyWindowBgBuffer(NULL, 0);
+                CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
                 sub_8012A18(0);
                 switch (DebugFieldMapWindow_GetInput()) {
                     case MENU_INPUT_A_PRESS:
@@ -132,7 +132,7 @@ UNUSED static void DebugMapViewer(void)
             sub_809D25C();
             sub_80A59DC();
             DrawDialogueBoxString_Async();
-            CopyWindowBgBuffer(NULL, 0);
+            CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
             ToggleWindowBgBuffer();
             nullsub_8(gGameOptionsRef->touchScreen);
             sub_8005180();

--- a/src/debug_field_map.c
+++ b/src/debug_field_map.c
@@ -38,7 +38,7 @@ UNUSED static void DebugMapViewer(void)
     sub_809975C();
     sub_809D0AC();
     ResetDialogueBox();
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     AllocGroundMapAction();
     while (TRUE) {
         bool8 quitMapView;
@@ -48,7 +48,7 @@ UNUSED static void DebugMapViewer(void)
         if (DebugFieldMapWindow_Init()) {
             DebugFieldMapWindow_MoveMenuTo(mapId);
             while (TRUE) {
-                CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+                CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
                 sub_8012A18(0);
                 switch (DebugFieldMapWindow_GetInput()) {
                     case MENU_INPUT_A_PRESS:
@@ -132,7 +132,7 @@ UNUSED static void DebugMapViewer(void)
             sub_809D25C();
             sub_80A59DC();
             DrawDialogueBoxString_Async();
-            CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+            CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
             ToggleWindowBgBuffer();
             nullsub_8(gGameOptionsRef->touchScreen);
             sub_8005180();

--- a/src/debug_field_map.c
+++ b/src/debug_field_map.c
@@ -133,7 +133,7 @@ UNUSED static void DebugMapViewer(void)
             sub_80A59DC();
             DrawDialogueBoxString_Async();
             sub_8005838(NULL, 0);
-            sub_80060EC();
+            ToggleWindowBgBuffer();
             nullsub_8(gGameOptionsRef->touchScreen);
             sub_8005180();
             sub_8099BE4();

--- a/src/dungeon_8041AD0.c
+++ b/src/dungeon_8041AD0.c
@@ -7,7 +7,7 @@
 #include "structs/dungeon_entity.h"
 #include "structs/sprite_oam.h"
 #include "structs/str_dungeon.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "effect_main.h"
 #include "effect_sub_1.h"
 #include "effect_sub_2.h"

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -303,7 +303,7 @@ static void sub_803F7BC(void)
     u32 roomId = tile->room;
 
     if (strPtr->allTilesRevealed != 0 || strPtr->unk1820C != 0 || strPtr->unk18217 != 0) {
-        CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+        CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     }
     else if (roomId == CORRIDOR_ROOM) {
         u32 kind = (strPtr->visibilityRange == 2) ? COPY_WINDOW_BG_BUFFER_DIM2 : COPY_WINDOW_BG_BUFFER_DIM1;

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -716,7 +716,7 @@ void sub_8040094(u8 r0)
 {
     gDungeon->unk181e8.unk18217 = r0;
     sub_803F7BC();
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     IncrementPlayTime(gPlayTimeRef);
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -303,11 +303,11 @@ static void sub_803F7BC(void)
     u32 roomId = tile->room;
 
     if (strPtr->allTilesRevealed != 0 || strPtr->unk1820C != 0 || strPtr->unk18217 != 0) {
-        sub_8005838(NULL, 0);
+        CopyWindowBgBuffer(NULL, 0);
     }
     else if (roomId == CORRIDOR_ROOM) {
         u32 kind = (strPtr->visibilityRange == 2) ? 1 : 2;
-        sub_8005838(NULL, kind);
+        CopyWindowBgBuffer(NULL, kind);
     }
     else {
         s32 sp[4];
@@ -317,7 +317,7 @@ static void sub_803F7BC(void)
         sp[1] = room->unk10 - strPtr->cameraPixelPos.y;
         sp[2] = room->unk14 - strPtr->cameraPixelPos.x;
         sp[3] = room->unk18 - strPtr->cameraPixelPos.y;
-        sub_8005838(sp, 3);
+        CopyWindowBgBuffer(sp, 3);
     }
 }
 

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -303,10 +303,10 @@ static void sub_803F7BC(void)
     u32 roomId = tile->room;
 
     if (strPtr->allTilesRevealed != 0 || strPtr->unk1820C != 0 || strPtr->unk18217 != 0) {
-        CopyWindowBgBuffer(NULL, 0);
+        CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     }
     else if (roomId == CORRIDOR_ROOM) {
-        u32 kind = (strPtr->visibilityRange == 2) ? 1 : 2;
+        u32 kind = (strPtr->visibilityRange == 2) ? COPY_WINDOW_BG_BUFFER_DIM2 : COPY_WINDOW_BG_BUFFER_DIM1;
         CopyWindowBgBuffer(NULL, kind);
     }
     else {

--- a/src/dungeon_tilemap.c
+++ b/src/dungeon_tilemap.c
@@ -6,7 +6,7 @@
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
 #include "code_8004AA0.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "effect_data.h"
 #include "confirm_name_menu.h"

--- a/src/dungeon_vram.c
+++ b/src/dungeon_vram.c
@@ -206,7 +206,7 @@ static void sub_803E490(u32 unused)
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     nullsub_12();
-    sub_80060EC();
+    ToggleWindowBgBuffer();
 
     gDungeonFramesCounter++;
 
@@ -240,7 +240,7 @@ void sub_803E668(u32 unused)
     sub_8005180();
     nullsub_12();
     sub_8005838(NULL, 0);
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     gDungeonFramesCounter++;
     IncrementPlayTime(gPlayTimeRef);
     WaitForNextFrameAndAdvanceRNG();

--- a/src/dungeon_vram.c
+++ b/src/dungeon_vram.c
@@ -239,7 +239,7 @@ void sub_803E668(u32 unused)
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     nullsub_12();
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     ToggleWindowBgBuffer();
     gDungeonFramesCounter++;
     IncrementPlayTime(gPlayTimeRef);

--- a/src/dungeon_vram.c
+++ b/src/dungeon_vram.c
@@ -5,7 +5,7 @@
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
 #include "code_8004AA0.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "code_800C9CC.h"
 #include "music_util.h"

--- a/src/dungeon_vram.c
+++ b/src/dungeon_vram.c
@@ -239,7 +239,7 @@ void sub_803E668(u32 unused)
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     nullsub_12();
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     ToggleWindowBgBuffer();
     gDungeonFramesCounter++;
     IncrementPlayTime(gPlayTimeRef);

--- a/src/dungeon_vram.c
+++ b/src/dungeon_vram.c
@@ -239,7 +239,7 @@ void sub_803E668(u32 unused)
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     nullsub_12();
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     ToggleWindowBgBuffer();
     gDungeonFramesCounter++;
     IncrementPlayTime(gPlayTimeRef);

--- a/src/friend_areas_map.c
+++ b/src/friend_areas_map.c
@@ -4,7 +4,7 @@
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
 #include "code_8004AA0.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "code_800C9CC.h"
 #include "code_800D090.h"

--- a/src/friend_areas_map_util.c
+++ b/src/friend_areas_map_util.c
@@ -373,7 +373,7 @@ void FriendAreasMap_RunFrameActions(void)
     SetBG3RegOffsets(gFriendAreasMapPtr->bgPos.x, gFriendAreasMapPtr->bgPos.y);
     AnimateSprites();
     UpdateAnimatedColors(FadeScreen(), gFriendAreasMapPtr->unk4C4C, 0xB0, 16, gFriendAreasMapPtr->brightness, NULL);
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     ToggleWindowBgBuffer();

--- a/src/friend_areas_map_util.c
+++ b/src/friend_areas_map_util.c
@@ -4,7 +4,7 @@
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
 #include "code_8004AA0.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "code_800C9CC.h"
 #include "code_800D090.h"

--- a/src/friend_areas_map_util.c
+++ b/src/friend_areas_map_util.c
@@ -376,7 +376,7 @@ void FriendAreasMap_RunFrameActions(void)
     sub_8005838(NULL, 0);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     IncrementPlayTime(gPlayTimeRef);
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();

--- a/src/friend_areas_map_util.c
+++ b/src/friend_areas_map_util.c
@@ -373,7 +373,7 @@ void FriendAreasMap_RunFrameActions(void)
     SetBG3RegOffsets(gFriendAreasMapPtr->bgPos.x, gFriendAreasMapPtr->bgPos.y);
     AnimateSprites();
     UpdateAnimatedColors(FadeScreen(), gFriendAreasMapPtr->unk4C4C, 0xB0, 16, gFriendAreasMapPtr->brightness, NULL);
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     ToggleWindowBgBuffer();

--- a/src/friend_areas_map_util.c
+++ b/src/friend_areas_map_util.c
@@ -373,7 +373,7 @@ void FriendAreasMap_RunFrameActions(void)
     SetBG3RegOffsets(gFriendAreasMapPtr->bgPos.x, gFriendAreasMapPtr->bgPos.y);
     AnimateSprites();
     UpdateAnimatedColors(FadeScreen(), gFriendAreasMapPtr->unk4C4C, 0xB0, 16, gFriendAreasMapPtr->brightness, NULL);
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     ToggleWindowBgBuffer();

--- a/src/ground_main.c
+++ b/src/ground_main.c
@@ -308,7 +308,7 @@ u32 xxx_script_related_8098468_Async(s32 startMode)
             GroundMap_ExecuteEvent(EVENT_DIVIDE, FALSE);
         }
         GroundMap_Action();
-        sub_8005838(NULL,0);
+        CopyWindowBgBuffer(NULL,0);
         ToggleWindowBgBuffer();
         xxx_call_update_bg_sound_input();
         while ( 1 ) {

--- a/src/ground_main.c
+++ b/src/ground_main.c
@@ -309,7 +309,7 @@ u32 xxx_script_related_8098468_Async(s32 startMode)
         }
         GroundMap_Action();
         sub_8005838(NULL,0);
-        sub_80060EC();
+        ToggleWindowBgBuffer();
         xxx_call_update_bg_sound_input();
         while ( 1 ) {
             xxx_call_update_bg_sound_input();

--- a/src/ground_main.c
+++ b/src/ground_main.c
@@ -308,7 +308,7 @@ u32 xxx_script_related_8098468_Async(s32 startMode)
             GroundMap_ExecuteEvent(EVENT_DIVIDE, FALSE);
         }
         GroundMap_Action();
-        CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+        CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
         ToggleWindowBgBuffer();
         xxx_call_update_bg_sound_input();
         while ( 1 ) {

--- a/src/ground_main.c
+++ b/src/ground_main.c
@@ -5,7 +5,7 @@
 #include "structs/str_wonder_mail.h"
 #include "structs/str_dungeon_setup.h"
 #include "adventure_info.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "code_800C9CC.h"
 #include "code_8094F88.h"
 #include "code_80958E8.h"

--- a/src/ground_main.c
+++ b/src/ground_main.c
@@ -308,7 +308,7 @@ u32 xxx_script_related_8098468_Async(s32 startMode)
             GroundMap_ExecuteEvent(EVENT_DIVIDE, FALSE);
         }
         GroundMap_Action();
-        CopyWindowBgBuffer(NULL,0);
+        CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
         ToggleWindowBgBuffer();
         xxx_call_update_bg_sound_input();
         while ( 1 ) {

--- a/src/ground_map.c
+++ b/src/ground_map.c
@@ -10,7 +10,7 @@
 #include "ground_weather.h"
 #include "memory.h"
 #include "ground_map_conversion_table.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "constants/dungeon.h"
 #include "constants/ground_map.h"
 #include "code_809D148.h"

--- a/src/ground_weather.c
+++ b/src/ground_weather.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "globaldata.h"
 #include "ground_weather.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "debug.h"
 #include "event_flag.h"
 #include "ground_bg.h"

--- a/src/main.c
+++ b/src/main.c
@@ -90,7 +90,7 @@ void AgbMain(void)
     nullsub_6();
     InitInput();
     InitBGPaletteBuffer();
-    sub_80057E8();
+    WindowBgBufferInit();
     InitFileSystem();
     LoadCharmaps();
     ResetScheduledMemCopies();

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,7 @@
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
 #include "code_8004AA0.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "cpu.h"
 #include "crt0.h"

--- a/src/main_loops.c
+++ b/src/main_loops.c
@@ -279,7 +279,7 @@ static void MainLoops_RunFrameActions(u32 unused)
     sub_8005180();
     // Extra call here in blue. Seems to be for 2nd screen sprites
 
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     UpdateSoundEffectCounters();
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();
@@ -363,7 +363,7 @@ static void QuickSave_Async(u32 mode)
     sub_8099750();
     SetCharacterMask(3);
     sub_8005838(NULL, 0);
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     CreateDialogueBoxAndPortrait(sSaveTextQuicksaving, 0, 0, 0x20);
 
     while (TRUE) {

--- a/src/main_loops.c
+++ b/src/main_loops.c
@@ -273,7 +273,7 @@ void GameLoop_Async(void)
 static void MainLoops_RunFrameActions(u32 unused)
 {
     DrawDialogueBoxString_Async();
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     nullsub_8(gGameOptionsRef->touchScreen);
 
     sub_8005180();
@@ -362,7 +362,7 @@ static void QuickSave_Async(u32 mode)
     sub_8099744();
     sub_8099750();
     SetCharacterMask(3);
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     ToggleWindowBgBuffer();
     CreateDialogueBoxAndPortrait(sSaveTextQuicksaving, 0, 0, 0x20);
 

--- a/src/main_loops.c
+++ b/src/main_loops.c
@@ -273,7 +273,7 @@ void GameLoop_Async(void)
 static void MainLoops_RunFrameActions(u32 unused)
 {
     DrawDialogueBoxString_Async();
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     nullsub_8(gGameOptionsRef->touchScreen);
 
     sub_8005180();
@@ -362,7 +362,7 @@ static void QuickSave_Async(u32 mode)
     sub_8099744();
     sub_8099750();
     SetCharacterMask(3);
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     ToggleWindowBgBuffer();
     CreateDialogueBoxAndPortrait(sSaveTextQuicksaving, 0, 0, 0x20);
 

--- a/src/main_loops.c
+++ b/src/main_loops.c
@@ -273,7 +273,7 @@ void GameLoop_Async(void)
 static void MainLoops_RunFrameActions(u32 unused)
 {
     DrawDialogueBoxString_Async();
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     nullsub_8(gGameOptionsRef->touchScreen);
 
     sub_8005180();
@@ -362,7 +362,7 @@ static void QuickSave_Async(u32 mode)
     sub_8099744();
     sub_8099750();
     SetCharacterMask(3);
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     ToggleWindowBgBuffer();
     CreateDialogueBoxAndPortrait(sSaveTextQuicksaving, 0, 0, 0x20);
 

--- a/src/main_loops.c
+++ b/src/main_loops.c
@@ -8,7 +8,7 @@
 #include "adventure_info.h"
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "code_800C9CC.h"
 #include "code_800D090_1.h"
 #include "code_8094F88.h"

--- a/src/menu_input.c
+++ b/src/menu_input.c
@@ -66,7 +66,7 @@ void sub_8012A18(s32 unused)
     DrawDialogueBoxString_Async();
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs(); // Input related
     CopySpritesToOam();

--- a/src/menu_input.c
+++ b/src/menu_input.c
@@ -16,7 +16,7 @@
 #include "code_800C9CC.h"
 #include "bg_palette_buffer.h"
 #include "game_options.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 
 const u32 gDefaultMenuTextColors[3] = { COLOR_WHITE_2, COLOR_RED, COLOR_RED };
 

--- a/src/other_menus1.c
+++ b/src/other_menus1.c
@@ -4,7 +4,7 @@
 #include "constants/main_menu.h"
 #include "structs/str_dungeon.h"
 #include "bg_palette_buffer.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "code_800C9CC.h"
 #include "music_util.h"

--- a/src/other_menus1.c
+++ b/src/other_menus1.c
@@ -208,7 +208,7 @@ static void sub_80371B8(void)
 
 void sub_80373C4(void)
 {
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     ToggleWindowBgBuffer();
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();

--- a/src/other_menus1.c
+++ b/src/other_menus1.c
@@ -208,7 +208,7 @@ static void sub_80371B8(void)
 
 void sub_80373C4(void)
 {
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     ToggleWindowBgBuffer();
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();

--- a/src/other_menus1.c
+++ b/src/other_menus1.c
@@ -209,7 +209,7 @@ static void sub_80371B8(void)
 void sub_80373C4(void)
 {
     sub_8005838(NULL, 0);
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();
     TransferBGPaletteBuffer();

--- a/src/other_menus1.c
+++ b/src/other_menus1.c
@@ -208,7 +208,7 @@ static void sub_80371B8(void)
 
 void sub_80373C4(void)
 {
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     ToggleWindowBgBuffer();
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();

--- a/src/run_dungeon.c
+++ b/src/run_dungeon.c
@@ -10,7 +10,7 @@
 #include "structs/sprite_oam.h"
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "effect_main.h"
 #include "effect_data.h"

--- a/src/text_1.c
+++ b/src/text_1.c
@@ -2,7 +2,7 @@
 #include "globaldata.h"
 #include "structs/str_text.h"
 #include "bg_palette_buffer.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "cpu.h"
 #include "decompress_at.h"

--- a/src/text_1.c
+++ b/src/text_1.c
@@ -37,7 +37,7 @@ EWRAM_INIT void (*ScrollUpWindowFunc)(s32 windowId) = ScrollUpWindow;
 EWRAM_INIT void (*gIwramTextFunc3)(s32 a0) = sub_82729A4;
 EWRAM_INIT void (*gIwramTextFunc4)(s32 a0) = sub_8272A78;
 
-IWRAM_DATA ALIGNED(4) s16 gUnknown_3000E94[161] = {0};
+IWRAM_DATA ALIGNED(4) s16 gWindowBg[161] = {0};
 
 const u32 gUnknown_80B853C[16] =
 {
@@ -160,7 +160,7 @@ void LoadCharmaps(void)
 
     gDrawTextShadow = 1;
     gTextShadowMask = 0x88888888;
-    gUnknown_203B078 = NULL;
+    gWindowBgCopy = NULL;
     gUnknown_20274A5 = FALSE;
     gUnknown_202B020 = 1;
     gUnknown_202B024 = 20;
@@ -266,18 +266,18 @@ static void ShowWindowsInternal(const WindowTemplates *winTemplates, bool8 a1, b
 
         if (winTemplates->id[i].width != 0) {
             AddWindow(gWindows, (u32 *)VRAM, sWindowGFXPool, gBgTilemaps, sUnknown_80B8804[i], &winTemplates->id[i], a1, startTileNum, positionModifier, FALSE);
-            sub_80089AC(&winTemplates->id[i], positionModifier);
+            DrawWindowBg(&winTemplates->id[i], positionModifier);
 
             startTileNum += winTemplates->id[i].width * winTemplates->id[i].totalHeight;
         }
     }
 
     // Needed to account for weird compiler LDRs
-    ASM_MATCH_TRICK(gUnknown_203B078);
-    ASM_MATCH_TRICK(gUnknown_3000E94[0]);
+    ASM_MATCH_TRICK(gWindowBgCopy);
+    ASM_MATCH_TRICK(gWindowBg[0]);
     ASM_MATCH_TRICK(gUnknown_20274A5);
 
-    gUnknown_203B078 = gUnknown_3000E94;
+    gWindowBgCopy = gWindowBg;
     gUnknown_20274A5 = TRUE;
 }
 

--- a/src/text_2.c
+++ b/src/text_2.c
@@ -1107,169 +1107,184 @@ void ResetWindowBgData(void)
 {
     s32 i;
 
-    for (i = 0; i < ARRAY_COUNT_INT(gUnknown_3000E94); i++) {
-        gUnknown_3000E94[i] = 0xF0F0;
+    for (i = 0; i < ARRAY_COUNT_INT(gWindowBg); i++) {
+        gWindowBg[i] = 0xF0F0;
     }
 }
 
-void sub_80089AC(const WindowTemplate *r4, DungeonPos *r5_Str)
+void DrawWindowBg(const WindowTemplate *window, DungeonPos *pos)
 {
-    u8 *r6;
+    const u8 WINH_DEFAULT = 0xF0;
+    const s32 Y_MAX = 160;
+    u8 *windowArr;
 
-    if (r4->flags & WINTEMPLATE_FLAG_x40)
+    if (window->flags & WINTEMPLATE_FLAG_x40)
         return;
 
-    r6 = (u8*) gUnknown_3000E94;
-    if (r4->type == WINDOW_TYPE_WITHOUT_BORDER) {
-        s32 r12 = (r4->pos.x + r5_Str->x) * 8;
-        s32 r5 = (r4->pos.y + r5_Str->y) * 8;
-        s32 r7 = (r4->pos.x + r5_Str->x + r4->width) * 8;
-        s32 r2 = (r4->pos.y + r5_Str->y + r4->height) * 8;
-        if (r4->height != 0) {
-            if (r5 < 0)
-                r5 = 0;
-            if (r2 < 0)
-                r2 = 0;
-            if (r5 > 160)
-                r5 = 160;
-            if (r2 > 160)
-                r2 = 160;
-            while (r5 < r2) {
-                s32 id = r5 * 2;
-                if (r6[id] == 240 && r6[id + 1] == 240) {
-                    r6[id++] = r7;
-                    r6[id] = r12;
+    windowArr = (u8*) gWindowBg;
+    if (window->type == WINDOW_TYPE_WITHOUT_BORDER) {
+        s32 xStart = (window->pos.x + pos->x) * 8;
+        s32 yStart = (window->pos.y + pos->y) * 8;
+        s32 xEnd = (window->pos.x + pos->x + window->width) * 8;
+        s32 yEnd = (window->pos.y + pos->y + window->height) * 8;
+        if (window->height != 0) {
+            if (yStart < 0)
+                yStart = 0;
+            if (yEnd < 0)
+                yEnd = 0;
+            if (yStart > Y_MAX)
+                yStart = Y_MAX;
+            if (yEnd > Y_MAX)
+                yEnd = Y_MAX;
+
+            // Draw window background
+            while (yStart < yEnd) {
+                s32 idx = yStart * 2;
+                if (windowArr[idx] == WINH_DEFAULT && windowArr[idx + 1] == WINH_DEFAULT) {
+                    windowArr[idx++] = xEnd;    // Right side of window
+                    windowArr[idx] = xStart;    // Left side of window
                 }
                 else {
-                    if (r6[id] < r7) {
-                        r6[id] = r7;
+                    // Only allow window to expand in size?
+                    // Right side of window
+                    if (windowArr[idx] < xEnd) {
+                        windowArr[idx] = xEnd;
                     }
-                    id++;
-                    if (r6[id] > r12) {
-                        r6[id] = r12;
+                    idx++;
+                    // Left side of window
+                    if (windowArr[idx] > xStart) {
+                        windowArr[idx] = xStart;
                     }
                 }
-                r5++;
+                yStart++;
             }
         }
     }
-    else if (r4->type == WINDOW_TYPE_WITH_HEADER) {
+    else if (window->type == WINDOW_TYPE_WITH_HEADER) {
         s32 i;
-        s32 r9 = ((r4->pos.x + r5_Str->x) * 8) - 5;
-        s32 r5 = ((r4->pos.y + r5_Str->y) * 8) - 4;
-        s32 var_24 = ((r4->pos.x + r5_Str->x + r4->width) * 8) + 5;
-        s32 r8 = ((r4->pos.y + r5_Str->y + r4->height) * 8) + 5;
-        s32 r12 = ((r4->pos.x + r5_Str->x) * 8) + 3;
-        const WindowHeader *r2 = r4->header;
-        s32 tmp = r2->width - 1;
-        s32 r10 = (((tmp + r2->count + 2) * 8) + r12) - 4;
-        s32 r4 = r9 + ((r2->currId + 1) * 8);
-        s32 r7 = (r4 + ((r2->width + 2) * 8)) - 4;
+        s32 xStart = ((window->pos.x + pos->x) * 8) - 5;
+        s32 yStart = ((window->pos.y + pos->y) * 8) - 4;
+        s32 xEnd = ((window->pos.x + pos->x + window->width) * 8) + 5;
+        s32 yEnd = ((window->pos.y + pos->y + window->height) * 8) + 5;
+        s32 allHeadersStart = ((window->pos.x + pos->x) * 8) + 3;
+        const WindowHeader *header = window->header;
+        s32 tmp = header->width - 1;
+        s32 allHeadersEnd = (((tmp + header->count + 2) * 8) + allHeadersStart) - 4;
+        s32 currHeaderStart = xStart + ((header->currId + 1) * 8);
+        s32 currHeaderEnd = (currHeaderStart + ((header->width + 2) * 8)) - 4;
 
-        if (r5 < 0)
-            r5 = 0;
-        if (r8 < 0)
-            r8 = 0;
-        if (r5 > 160)
-            r5 = 160;
-        if (r8 > 160)
-            r8 = 160;
+        if (yStart < 0)
+            yStart = 0;
+        if (yEnd < 0)
+            yEnd = 0;
+        if (yStart > Y_MAX)
+            yStart = Y_MAX;
+        if (yEnd > Y_MAX)
+            yEnd = Y_MAX;
 
         // BUG: The background array is 161 entries long, but this function will potentially write
         // up to index 160 + 12 = 172, overflowing the array.
 #ifdef UBFIX
-        if (r5 > 160 - 12) {
-            r5 = 160 - 12;
+        if (yStart > Y_MAX - 12) {
+            yStart = Y_MAX - 12;
         }
 #endif
 
+        // Draw extra header background for current tab
+        // For multi-tabbed windows, the current tab is taller, so need to draw an extra 4 pixels of BG
         for (i = 0; i < 4; i++) {
-            s32 id = r5 * 2;
-            if (r6[id] == 240 && r6[id + 1] == 240) {
-                r6[id++] = r7;
-                r6[id] = r4;
+            s32 idx = yStart * 2;
+            if (windowArr[idx] == WINH_DEFAULT && windowArr[idx + 1] == WINH_DEFAULT) {
+                windowArr[idx++] = currHeaderEnd;  // Right side of window
+                windowArr[idx] = currHeaderStart;    // Left side of window
             }
             else {
-                if (r6[id] < r7) {
-                    r6[id] = r7;
+                // Only allow window to expand in size?
+                // Right side of window
+                if (windowArr[idx] < currHeaderEnd) {
+                    windowArr[idx] = currHeaderEnd;
                 }
-                id++;
-                if (r6[id] > r4) {
-                    r6[id] = r4;
-                }
-            }
-            r5++;
-        }
-        for (i = 0; i < 8; i++) {
-            s32 id = r5 * 2;
-            if (r6[id] == 240 && r6[id + 1] == 240) {
-                r6[id++] = r10;
-                r6[id] = r12;
-            }
-            else {
-                if (r6[id] < r10) {
-                    r6[id] = r10;
-                }
-                id++;
-                if (r6[id] > r12) {
-                    r6[id] = r12;
+                idx++;
+                // Left side of window
+                if (windowArr[idx] > currHeaderStart) {
+                    windowArr[idx] = currHeaderStart;
                 }
             }
-            r5++;
+            yStart++;
         }
 
-        while (r5 < r8) {
-            s32 id = r5 * 2;
-            if (r6[id] == 240 && r6[id + 1] == 240) {
-                r6[id++] = var_24;
-                r6[id] = r9;
+        // Draw header background for all tabs
+        for (i = 0; i < 8; i++) {
+            s32 id = yStart * 2;
+            if (windowArr[id] == WINH_DEFAULT && windowArr[id + 1] == WINH_DEFAULT) {
+                windowArr[id++] = allHeadersEnd;  // Right side of window
+                windowArr[id] = allHeadersStart;    // Left side of window
             }
             else {
-                if (r6[id] < var_24) {
-                    r6[id] = var_24;
+                if (windowArr[id] < allHeadersEnd) {
+                    windowArr[id] = allHeadersEnd;
                 }
                 id++;
-                if (r6[id] > r9) {
-                    r6[id] = r9;
+                if (windowArr[id] > allHeadersStart) {
+                    windowArr[id] = allHeadersStart;
                 }
             }
-            r5++;
+            yStart++;
+        }
+
+        // Draw main window background
+        while (yStart < yEnd) {
+            s32 idx = yStart * 2;
+            if (windowArr[idx] == WINH_DEFAULT && windowArr[idx + 1] == WINH_DEFAULT) {
+                windowArr[idx++] = xEnd;    // Right side of window
+                windowArr[idx] = xStart;    // Left side of window
+            }
+            else {
+                if (windowArr[idx] < xEnd) {
+                    windowArr[idx] = xEnd;
+                }
+                idx++;
+                if (windowArr[idx] > xStart) {
+                    windowArr[idx] = xStart;
+                }
+            }
+            yStart++;
         }
     }
     else {
-        s32 r8 = ((r4->pos.x + r5_Str->x) * 8) - 5;
-        s32 r3 = ((r4->pos.y + r5_Str->y) * 8) - 5;
-        s32 r12 = ((r4->pos.x + r5_Str->x + r4->width) * 8) + 5;
-        s32 r5 = ((r4->pos.y + r5_Str->y + r4->height) * 8) + 5;
-        if (r4->height != 0) {
-            if (r4->type == 0) {
-                r3 += 8;
-                r5 = ((r4->pos.y + r5_Str->y + r4->height) * 8) - 3;
+        s32 xStart = ((window->pos.x + pos->x) * 8) - 5;
+        s32 yStart = ((window->pos.y + pos->y) * 8) - 5;
+        s32 xEnd = ((window->pos.x + pos->x + window->width) * 8) + 5;
+        s32 yEnd = ((window->pos.y + pos->y + window->height) * 8) + 5;
+        if (window->height != 0) {
+            if (window->type == WINDOW_TYPE_0) {
+                yStart += 8;
+                yEnd = ((window->pos.y + pos->y + window->height) * 8) - 3;
             }
-            if (r3 < 0)
-                r3 = 0;
-            if (r5 < 0)
-                r5 = 0;
-            if (r3 > 160)
-                r3 = 160;
-            if (r5 > 160)
-                r5 = 160;
-            while (r3 < r5) {
-                s32 id = r3 * 2;
-                if (r6[id] == 240 && r6[id + 1] == 240) {
-                    r6[id++] = r12;
-                    r6[id] = r8;
+            if (yStart < 0)
+                yStart = 0;
+            if (yEnd < 0)
+                yEnd = 0;
+            if (yStart > Y_MAX)
+                yStart = Y_MAX;
+            if (yEnd > Y_MAX)
+                yEnd = Y_MAX;
+            while (yStart < yEnd) {
+                s32 idx = yStart * 2;
+                if (windowArr[idx] == WINH_DEFAULT && windowArr[idx + 1] == WINH_DEFAULT) {
+                    windowArr[idx++] = xEnd;    // Right side of window
+                    windowArr[idx] = xStart;    // Left side of window
                 }
                 else {
-                    if (r6[id] < r12) {
-                        r6[id] = r12;
+                    if (windowArr[idx] < xEnd) {
+                        windowArr[idx] = xEnd;
                     }
-                    id++;
-                    if (r6[id] > r8) {
-                        r6[id] = r8;
+                    idx++;
+                    if (windowArr[idx] > xStart) {
+                        windowArr[idx] = xStart;
                     }
                 }
-                r3++;
+                yStart++;
             }
         }
     }

--- a/src/textbox.c
+++ b/src/textbox.c
@@ -1040,7 +1040,7 @@ void sub_809B57C_Async(void)
     }
 
     if (sTextbox->unk434 < 0) {
-        CopyWindowBgBuffer(0, 0);
+        CopyWindowBgBuffer(0, COPY_WINDOW_BG_BUFFER_DEFAULT);
     }
     else {
         CopyWindowBgBuffer(0, 5);

--- a/src/textbox.c
+++ b/src/textbox.c
@@ -1040,10 +1040,10 @@ void sub_809B57C_Async(void)
     }
 
     if (sTextbox->unk434 < 0) {
-        sub_8005838(0, 0);
+        CopyWindowBgBuffer(0, 0);
     }
     else {
-        sub_8005838(0, 5);
+        CopyWindowBgBuffer(0, 5);
     }
 }
 

--- a/src/textbox.c
+++ b/src/textbox.c
@@ -1040,7 +1040,7 @@ void sub_809B57C_Async(void)
     }
 
     if (sTextbox->unk434 < 0) {
-        CopyWindowBgBuffer(0, COPY_WINDOW_BG_BUFFER_DEFAULT);
+        CopyWindowBgBuffer(0, COPY_WINDOW_BG_BUFFER_WIN0);
     }
     else {
         CopyWindowBgBuffer(0, 5);

--- a/src/textbox.c
+++ b/src/textbox.c
@@ -5,7 +5,7 @@
 #include "structs/menu.h"
 #include "structs/str_file_system.h"
 #include "structs/str_mon_portrait.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "code_800D090.h"
 #include "code_8015080.h"
 #include "code_801B60C.h"

--- a/src/textbox.c
+++ b/src/textbox.c
@@ -1049,7 +1049,7 @@ void sub_809B57C_Async(void)
 
 void sub_809B614(void)
 {
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     gUnknown_20399DE = gUnknown_20399DC;
     gUnknown_20399DC &= ~2;
 }

--- a/src/window_buffer.c
+++ b/src/window_buffer.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "globaldata.h"
 #include "bg_control.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "math.h"
 
 #define UNROLL16(x) do { x; x; x; x; x; x; x; x; x; x; x; x; x; x; x; x; } while (0)

--- a/src/world_map.c
+++ b/src/world_map.c
@@ -406,7 +406,7 @@ static void WorldMap_RunFrameActions(void)
     SetBG3RegOffsets(sWorldMapPtr->bgPos.x, sWorldMapPtr->bgPos.y);
     AnimateSprites(TRUE);
     FadeScreen();
-    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_WIN0);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     ToggleWindowBgBuffer();

--- a/src/world_map.c
+++ b/src/world_map.c
@@ -406,7 +406,7 @@ static void WorldMap_RunFrameActions(void)
     SetBG3RegOffsets(sWorldMapPtr->bgPos.x, sWorldMapPtr->bgPos.y);
     AnimateSprites(TRUE);
     FadeScreen();
-    sub_8005838(NULL, 0);
+    CopyWindowBgBuffer(NULL, 0);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     ToggleWindowBgBuffer();

--- a/src/world_map.c
+++ b/src/world_map.c
@@ -409,7 +409,7 @@ static void WorldMap_RunFrameActions(void)
     sub_8005838(NULL, 0);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
-    sub_80060EC();
+    ToggleWindowBgBuffer();
     IncrementPlayTime(gPlayTimeRef);
     WaitForNextFrameAndAdvanceRNG();
     LoadBufferedInputs();

--- a/src/world_map.c
+++ b/src/world_map.c
@@ -3,7 +3,7 @@
 #include "bg_control.h"
 #include "bg_palette_buffer.h"
 #include "code_8004AA0.h"
-#include "code_800558C.h"
+#include "window_buffer.h"
 #include "graphics_memory.h"
 #include "code_800C9CC.h"
 #include "code_800D090.h"

--- a/src/world_map.c
+++ b/src/world_map.c
@@ -406,7 +406,7 @@ static void WorldMap_RunFrameActions(void)
     SetBG3RegOffsets(sWorldMapPtr->bgPos.x, sWorldMapPtr->bgPos.y);
     AnimateSprites(TRUE);
     FadeScreen();
-    CopyWindowBgBuffer(NULL, 0);
+    CopyWindowBgBuffer(NULL, COPY_WINDOW_BG_BUFFER_DEFAULT);
     nullsub_8(gGameOptionsRef->touchScreen);
     sub_8005180();
     ToggleWindowBgBuffer();

--- a/sym_ewram.txt
+++ b/sym_ewram.txt
@@ -6,7 +6,7 @@
     .include "src/bg_palette_buffer.o"
     .include "src/input.o"
     .include "src/sprite.o"
-    .include "src/code_800558C.o"
+    .include "src/window_buffer.o"
     .include "src/text_1.o"
     .include "src/graphics_memory.o"
     .include "src/file_system.o"

--- a/sym_ewram_init.txt
+++ b/sym_ewram_init.txt
@@ -3,7 +3,7 @@
 .include "src/main_loops.o"
 .include "src/other_random.o"
 .include "src/sprite.o"
-.include "src/code_800558C.o"
+.include "src/window_buffer.o"
 .include "src/random.o"
 .include "src/text_1.o"
 .include "src/graphics_memory.o"


### PR DESCRIPTION
Refactor and document functions to handle GBA windows.

Looks like in addition to the normal menu and text box windows using WIN0, GBA windows are also used to dim the screen in dungeons with low visibility with WIN1. Windows dimensions can be changed per row, DMA writes to the window registers every HBlank. There is also a double buffering system going on when setting up the DMA presumably to prevent modifying the data while DMA is copying it.