### PR TITLE
C23 Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ ifeq ($(MODERN),0)
     LIB := -L ../../tools/agbcc/lib -lc -lgcc -L ../../libagbsyscall -lagbsyscall
   endif
   INCLUDE_PATHS   := -I include -I tools/agbcc/include
-  CPPFLAGS        := -iquote include -I tools/agbcc/include -nostdinc -undef
+  CPPFLAGS        := -iquote include -I tools/agbcc/include -nostdinc -undef -std=gnu89
 else
   MODERNCC := $(PREFIX)gcc
   PATH_MODERNCC := PATH="$(PATH)" $(MODERNCC)

--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -170,7 +170,11 @@ struct SoundChannel
 
 struct MusicPlayerInfo;
 
+#if __STDC_VERSION__ < 202311L
 typedef void (*MPlayFunc)();
+#else
+typedef void (*MPlayFunc)(...);
+#endif
 typedef void (*PlyNoteFunc)(u32, struct MusicPlayerInfo *, struct MusicPlayerTrack *);
 typedef void (*CgbSoundFunc)(void);
 typedef void (*CgbOscOffFunc)(u8);
@@ -224,38 +228,6 @@ struct SongHeader
     u8 reverb;
     struct ToneData *tone;
     u8 *part[1];
-};
-
-struct PokemonCrySong
-{
-    u8 trackCount;
-    u8 blockCount;
-    u8 priority;
-    u8 reverb;
-    struct ToneData *tone;
-    u8 *part[2];
-    u8 gap;
-    u8 part0; // 0x11
-    u8 tuneValue; // 0x12
-    u8 gotoCmd; // 0x13
-    u32 gotoTarget; // 0x14
-    u8 part1; // 0x18
-    u8 tuneValue2; // 0x19
-    u8 cont[2]; // 0x1A
-    u8 volCmd; // 0x1C
-    u8 volumeValue; // 0x1D
-    u8 unkCmd0D[2]; // 0x1E
-    u32 unkCmd0DParam; // 0x20
-    u8 xreleCmd[2]; // 0x24
-    u8 releaseValue; // 0x26
-    u8 panCmd;
-    u8 panValue; // 0x28
-    u8 tieCmd; // 0x29
-    u8 tieKeyValue; // 0x2A
-    u8 tieVelocityValue; // 0x2B
-    u8 unkCmd0C[2]; // 0x2C
-    u16 unkCmd0CParam; // 0x2E
-    u8 end[2]; // 0x30
 };
 
 #define MPT_FLG_VOLSET 0x01
@@ -365,17 +337,6 @@ extern const struct Song gSongTable[];
 
 extern u8 gMPlayMemAccArea[];
 
-//u8 gPokemonCrySong[52];
-//u8 gPokemonCrySongs[52 * MAX_POKEMON_CRIES];
-
-#define MAX_POKEMON_CRIES 2
-
-extern struct PokemonCrySong gPokemonCrySong;
-extern struct PokemonCrySong gPokemonCrySongs[];
-
-extern struct MusicPlayerInfo gPokemonCryMusicPlayers[];
-extern struct MusicPlayerTrack gPokemonCryTracks[];
-
 extern char SoundMainRAM[];
 
 extern MPlayFunc gMPlayJumpTable[];
@@ -392,10 +353,6 @@ extern const u16 gPcmSamplesPerVBlankTable[];
 extern const u8 gCgbScaleTable[];
 extern const s16 gCgbFreqTable[];
 extern const u8 gNoiseTable[];
-
-extern const struct PokemonCrySong gPokemonCrySongTemplate;
-
-extern const struct ToneData voicegroup_pokemon_cry;
 
 extern char gNumMusicPlayers[];
 extern char gMaxLines[];
@@ -434,18 +391,6 @@ void m4aSoundVSyncOff(void);
 void ClearModM(struct MusicPlayerTrack *track);
 void m4aMPlayModDepthSet(struct MusicPlayerInfo *mplayInfo, u16 trackBits, u8 modDepth);
 void m4aMPlayLFOSpeedSet(struct MusicPlayerInfo *mplayInfo, u16 trackBits, u8 lfoSpeed);
-
-struct MusicPlayerInfo *SetPokemonCryTone(struct ToneData *tone);
-void SetPokemonCryVolume(u8 val);
-void SetPokemonCryPanpot(s8 val);
-void SetPokemonCryPitch(s16 val);
-void SetPokemonCryLength(u16 val);
-void SetPokemonCryRelease(u8 val);
-void SetPokemonCryProgress(u32 val);
-int IsPokemonCryPlaying(struct MusicPlayerInfo *mplayInfo);
-void SetPokemonCryChorus(s8 val);
-void SetPokemonCryStereo(u32 val);
-void SetPokemonCryPriority(u8 val);
 
 // sound command handler functions
 void ply_fine(struct MusicPlayerInfo *, struct MusicPlayerTrack *);

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -1494,8 +1494,8 @@ void ply_memacc(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *trac
 
 cond_true:
     {
-        void (*func)(struct MusicPlayerInfo *, struct MusicPlayerTrack *) = *(&gMPlayJumpTable[1]);
-        func(mplayInfo, track);
+        // *& is required for matching
+        (*&gMPlayJumpTable[1])(mplayInfo, track);
         return;
     }
 
@@ -1513,8 +1513,7 @@ void ply_xcmd(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track)
 
 void ply_xxx(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track)
 {
-    void (*func)(struct MusicPlayerInfo *, struct MusicPlayerTrack *) = *(&gMPlayJumpTable[0]);
-    func(mplayInfo, track);
+    gMPlayJumpTable[0](mplayInfo, track);
 }
 
 #define READ_XCMD_BYTE(var, n)       \

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -267,6 +267,7 @@ void MPlayExtender(struct CgbChannel *cgbChans)
 
     soundInfo->ident++;
 
+#if __STDC_VERSION__ < 202311L
     gMPlayJumpTable[8] = ply_memacc;
     gMPlayJumpTable[17] = ply_lfos;
     gMPlayJumpTable[19] = ply_mod;
@@ -276,6 +277,17 @@ void MPlayExtender(struct CgbChannel *cgbChans)
     gMPlayJumpTable[31] = TrackStop;
     gMPlayJumpTable[32] = FadeOutBody;
     gMPlayJumpTable[33] = TrkVolPitSet;
+#else
+    gMPlayJumpTable[8] = (void (*)(...))ply_memacc;
+    gMPlayJumpTable[17] = (void (*)(...))ply_lfos;
+    gMPlayJumpTable[19] = (void (*)(...))ply_mod;
+    gMPlayJumpTable[28] = (void (*)(...))ply_xcmd;
+    gMPlayJumpTable[29] = (void (*)(...))ply_endtie;
+    gMPlayJumpTable[30] = (void (*)(...))SampleFreqSet;
+    gMPlayJumpTable[31] = (void (*)(...))TrackStop;
+    gMPlayJumpTable[32] = (void (*)(...))FadeOutBody;
+    gMPlayJumpTable[33] = (void (*)(...))TrkVolPitSet;
+#endif
 
     soundInfo->cgbChans = cgbChans;
     soundInfo->CgbSound = CgbSound;
@@ -304,13 +316,21 @@ void MusicPlayerJumpTableCopy(void)
 
 void ClearChain(void *x)
 {
+#if __STDC_VERSION__ < 202311L
     void (*func)(void *) = *(&gMPlayJumpTable[34]);
+#else
+    void (*func)(...) = *(&gMPlayJumpTable[34]);
+#endif
     func(x);
 }
 
 void Clear64byte(void *x)
 {
+#if __STDC_VERSION__ < 202311L
     void (*func)(void *) = *(&gMPlayJumpTable[35]);
+#else
+    void (*func)(...) = *(&gMPlayJumpTable[35]);
+#endif
     func(x);
 }
 


### PR DESCRIPTION
Makes modern compatible with C23 (the default as of gcc 15). The offending functions were all in m4a and have simply been ported from the corresponding commit in pokeemerald. This also included fixing a couple of odd fakematches.

Also removed all of the extra unnecessary cry-related junk from `m4a_internal.h` that was leftover from the mainline repos.